### PR TITLE
#42 Support for 9.5beta2, add remote quals

### DIFF
--- a/ogr_fdw.c
+++ b/ogr_fdw.c
@@ -596,7 +596,8 @@ ogrGetForeignPlan(PlannerInfo *root,
 /*
 * Require PostgreSQL >= 9.5
 */
-						NIL  /* no scan_tlist */
+							NIL,  /* no scan_tlist */
+							NIL   /* no remote quals */ 
 #endif
 ); 
 


### PR DESCRIPTION
I tested before this change and confirmed that 9.5beta2 does not compile without this.  Also tested 9.4 to make sure I didn't break 9.4