### PR TITLE
Fix compilation issue with (old, but old only?) GCC due to PRId64

### DIFF
--- a/ogr_fdw.c
+++ b/ogr_fdw.c
@@ -48,11 +48,8 @@ struct OgrFdwOption
 #define OPT_CONFIG_OPTIONS "config_options"
 #define OPT_OPEN_OPTIONS "open_options"
 
-#ifdef WIN32
-# define OGR_FDW_FRMT_GIB "%lld"
-#else
-# define OGR_FDW_FRMT_GIB PRId64
-#endif
+#define OGR_FDW_FRMT_INT64	 "%lld"
+#define OGR_FDW_CAST_INT64(x)	 (long long)(x)
 
 /*
  * Valid options for ogr_fdw.
@@ -1342,7 +1339,7 @@ ogrFeatureToSlot(const OGRFeatureH feat, TupleTableSlot *slot, const OgrFdwTable
 			else
 			{
 				char fidstr[256];
-				snprintf(fidstr, 256, OGR_FDW_FRMT_GIB, fid);
+				snprintf(fidstr, 256, OGR_FDW_FRMT_INT64, OGR_FDW_CAST_INT64(fid));
 
 				nulls[i] = false;
 				values[i] = pgDatumFromCString(fidstr, pgtype, pgtypmod, pginputfunc);
@@ -1988,7 +1985,7 @@ static TupleTableSlot *ogrExecForeignUpdate (EState *estate,
 	else
 		fid = DatumGetInt32(fid_datum);
 
-	elog(DEBUG2, "ogrExecForeignUpdate fid=" OGR_FDW_FRMT_GIB, fid);
+	elog(DEBUG2, "ogrExecForeignUpdate fid=" OGR_FDW_FRMT_INT64, OGR_FDW_CAST_INT64(fid));
 	
 	/* Get the OGR feature for this fid */
 	feat = OGR_L_GetFeature (modstate->ogr.lyr, fid);
@@ -2174,7 +2171,7 @@ static TupleTableSlot *ogrExecForeignDelete (EState *estate,
 	else
 		fid = DatumGetInt32(fid_datum);
 	
-	elog(DEBUG2, "ogrExecForeignDelete fid=" OGR_FDW_FRMT_GIB, fid);
+	elog(DEBUG2, "ogrExecForeignDelete fid=" OGR_FDW_FRMT_INT64, OGR_FDW_CAST_INT64(fid));
 	
 	/* Delete the OGR feature for this fid */
 	err = OGR_L_DeleteFeature(modstate->ogr.lyr, fid);


### PR DESCRIPTION
Use of PRId64 was added in 8d0fb7b2b95fc71ffaebf3f8929b52f45194a9c3 (#66)
but this caused compilation error. If WIN32 build support "%lld", then
use it for all platforms, and add a cast macro to cast to long long.

@robe2 Could you confirm this works for Windows ?