### PR TITLE
Add Travis setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,19 @@
 sudo: required
 
+compiler: gcc
+
+
+matrix:
+  include:
+    - os: linux
+      language: c
+      env:
+        - GDAL_VERSION=1
+    - os: linux
+      language: cpp
+      env:
+        - GDAL_VERSION=2
+
 before_script:
   - sudo /etc/init.d/postgresql stop
   - sudo apt-get -y remove --purge postgresql-9.1
@@ -15,12 +29,8 @@ before_script:
   - sudo sh -c 'echo -n "host all all 127.0.0.1/32 trust" >> /etc/postgresql/9.5/main/pg_hba.conf'
   - sudo /etc/init.d/postgresql restart
   - psql --version
-# Would be nice to have GDAL 2
-  - sudo apt-get install libgdal-dev
-
-language: c
-
-compiler: gcc
+  - if test "$GDAL_VERSION" = "1"; then sudo apt-get install libgdal-dev; fi
+  - if test "$GDAL_VERSION" = "2"; then wget http://download.osgeo.org/gdal/2.0.2/gdal-2.0.2.tar.xz; tar xJf gdal-2.0.2.tar.xz; cd gdal-2.0.2; ./configure --prefix=/usr --enable-debug --without-libtool; make -j4 >/dev/null; sudo make install >/dev/null; cd ..; gdalinfo --version; fi
 
 script:
   - make

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,28 @@
+sudo: required
+
+before_script:
+  - sudo /etc/init.d/postgresql stop
+  - sudo apt-get -y remove --purge postgresql-9.1
+  - sudo apt-get -y remove --purge postgresql-9.2
+  - sudo apt-get -y remove --purge postgresql-9.3
+  - sudo apt-get -y remove --purge postgresql-9.4
+  - sudo apt-get -y autoremove
+  - sudo apt-key adv --keyserver keys.gnupg.net --recv-keys 7FCC7D46ACCC4CF8
+  - sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt/ precise-pgdg main 9.5" >> /etc/apt/sources.list.d/postgresql.list'
+  - sudo apt-get update
+  - sudo apt-get -y install postgresql-9.5 postgresql-server-dev-9.5
+  - sudo sh -c 'echo "local all all trust" > /etc/postgresql/9.5/main/pg_hba.conf'
+  - sudo sh -c 'echo -n "host all all 127.0.0.1/32 trust" >> /etc/postgresql/9.5/main/pg_hba.conf'
+  - sudo /etc/init.d/postgresql restart
+  - psql --version
+# Would be nice to have GDAL 2
+  - sudo apt-get install libgdal-dev
+
+language: c
+
+compiler: gcc
+
+script:
+  - make
+  - sudo make install
+  - PGUSER=postgres make installcheck || (cat regression.diffs && /bin/false)

--- a/ogr_fdw.c
+++ b/ogr_fdw.c
@@ -249,12 +249,14 @@ ogrGetDataSource(const char *source, const char *driver, bool updateable,
 	GDALDatasetH ogr_ds = NULL;
 	GDALDriverH ogr_dr = NULL;
 	char **open_option_list = NULL;
+#if GDAL_VERSION_MAJOR >= 2
 	unsigned int open_flags = GDAL_OF_VECTOR;
 	
 	if ( updateable )
 		open_flags |= GDAL_OF_UPDATE;
 	else
 		open_flags |= GDAL_OF_READONLY;
+#endif
 
 	if ( config_options )
 	{
@@ -2383,8 +2385,6 @@ ogrImportForeignSchema(ImportForeignSchemaStmt *stmt, Oid serverOid)
 				pggeomtype = "bytea";
 			else
 				pggeomtype = "geometry";
-
-			geom_field_count = OGR_FD_GetGeomFieldCount(ogr_fd);
 
 			if( geom_field_count == 1 )
 			{

--- a/ogr_fdw.c
+++ b/ogr_fdw.c
@@ -592,7 +592,6 @@ ogr_fdw_validator(PG_FUNCTION_ARGS)
 		{
 			GDALClose(ogr_ds);
 		}
-		OGRCleanupAll();
 	}
 
 	PG_RETURN_VOID();


### PR DESCRIPTION
Fixes a few bugs against GDAL 1.X (used by Travis) and add .travis.yml

Example of successful build: https://travis-ci.org/rouault/pgsql-ogr-fdw/builds/125359722

Note: this was based on top of c0b2d4ef04671accef3516239ec192fa0f53d256. To be applied on top of master, will require applying https://github.com/pramsey/pgsql-ogr-fdw/pull/70 first