### PR TITLE
Use bigint for fid in ogrGenerateSQL() and ogr_fdw_info

### DIFF
--- a/ogr_fdw.c
+++ b/ogr_fdw.c
@@ -2380,7 +2380,7 @@ ogrImportForeignSchema(ImportForeignSchemaStmt *stmt, Oid serverOid)
 			resetStringInfo(&buf);
 
 			appendStringInfo(&buf, "CREATE FOREIGN TABLE %s (\n", quote_identifier(table_name));
-			appendStringInfoString(&buf, " fid integer");
+			appendStringInfoString(&buf, " fid bigint");
 
 			/* What column type to use for OGR geometries? */
 			if ( GEOMETRYOID == BYTEAOID )

--- a/ogr_fdw_info.c
+++ b/ogr_fdw_info.c
@@ -201,7 +201,7 @@ ogrGenerateSQL(const char *source, const char *layer)
 
 	/* Output TABLE definition */
 	printf("CREATE FOREIGN TABLE %s (\n", layer_name);
-	printf("  fid integer");
+	printf("  fid bigint");
 #if GDAL_VERSION_MAJOR >= 2 || GDAL_VERSION_MINOR >= 11
 	geom_field_count = OGR_FD_GetGeomFieldCount(ogr_fd);
 	if( geom_field_count == 1 )


### PR DESCRIPTION
I'm not sure if there's an inconvenient in doing that systemtically,
but it helps with some datasources like OSM.
Seems to fix issue #59 for me (though I didn't get the same warnings
as the one in the ticket)

This commit, originally from https://github.com/pramsey/pgsql-ogr-fdw/pull/63, got lost.