### PR TITLE
Add first N columns as geom columns

### DIFF
--- a/input/ogr_fdw.source
+++ b/input/ogr_fdw.source
@@ -100,7 +100,7 @@ CREATE TABLE bytea_local (
   happened time
 );
 INSERT INTO bytea_local VALUES 
-  (1, 'Jim', '14232'::bytea, 1111, '99999'::bytea, '13:23:21'::time);
+  (1, 'Jim', '14232'::bytea, 1112, '99999'::bytea, '13:23:21'::time);
 INSERT INTO bytea_local VALUES 
   (2, 'James', '55555'::bytea, 2222, '88888'::bytea, '15:55:55'::time);
 

--- a/input/ogr_fdw.source
+++ b/input/ogr_fdw.source
@@ -100,9 +100,9 @@ CREATE TABLE bytea_local (
   happened time
 );
 INSERT INTO bytea_local VALUES 
-  (1, 'Jim', '14232'::bytea, 8142312312, '99999'::bytea, '13:23:21'::time);
+  (1, 'Jim', '14232'::bytea, 1111, '99999'::bytea, '13:23:21'::time);
 INSERT INTO bytea_local VALUES 
-  (2, 'James', '55555'::bytea, 9124231543, '88888'::bytea, '15:55:55'::time);
+  (2, 'James', '55555'::bytea, 2222, '88888'::bytea, '15:55:55'::time);
 
 SELECT * FROM bytea_local;
   

--- a/input/ogr_fdw.source
+++ b/input/ogr_fdw.source
@@ -83,3 +83,38 @@ CREATE SCHEMA ntrl;
 IMPORT FOREIGN SCHEMA ogr_all LIMIT TO ("natural") FROM SERVER myserver INTO ntrl;
 SELECT "natural" FROM ntrl."natural";
 
+------------------------------------------------
+
+CREATE SERVER pgserver
+  FOREIGN DATA WRAPPER ogr_fdw
+  OPTIONS (
+    datasource 'PG:dbname=contrib_regression host=localhost',
+    format 'PostgreSQL' );
+
+CREATE TABLE bytea_local (
+  fid integer primary key,
+  name varchar,
+  geom bytea,
+  age bigint,
+  bin bytea,
+  happened time
+);
+INSERT INTO bytea_local VALUES 
+  (1, 'Jim', '14232'::bytea, 8142312312, '99999'::bytea, '13:23:21'::time);
+INSERT INTO bytea_local VALUES 
+  (2, 'James', '55555'::bytea, 9124231543, '88888'::bytea, '15:55:55'::time);
+
+SELECT * FROM bytea_local;
+  
+CREATE FOREIGN TABLE bytea_fdw (
+  fid integer,
+  name text,
+  geom bytea,
+  age bigint,
+  bin bytea,
+  happened time
+) SERVER pgserver OPTIONS (layer 'bytea_local');
+
+SELECT * FROM bytea_fdw;
+EXPLAIN VERBOSE SELECT * FROM bytea_fdw;
+

--- a/output/ogr_fdw.source
+++ b/output/ogr_fdw.source
@@ -117,13 +117,13 @@ CREATE TABLE bytea_local (
   happened time
 );
 INSERT INTO bytea_local VALUES 
-  (1, 'Jim', '14232'::bytea, 1111, '99999'::bytea, '13:23:21'::time);
+  (1, 'Jim', '14232'::bytea, 1112, '99999'::bytea, '13:23:21'::time);
 INSERT INTO bytea_local VALUES 
   (2, 'James', '55555'::bytea, 2222, '88888'::bytea, '15:55:55'::time);
 SELECT * FROM bytea_local;
  fid | name  |     geom     | age  |     bin      | happened 
 -----+-------+--------------+------+--------------+----------
-   1 | Jim   | \x3134323332 | 1111 | \x3939393939 | 13:23:21
+   1 | Jim   | \x3134323332 | 1112 | \x3939393939 | 13:23:21
    2 | James | \x3535353535 | 2222 | \x3838383838 | 15:55:55
 (2 rows)
 
@@ -139,7 +139,7 @@ CREATE FOREIGN TABLE bytea_fdw (
 SELECT * FROM bytea_fdw;
  fid | name  |     geom     | age  |     bin      | happened 
 -----+-------+--------------+------+--------------+----------
-   1 | Jim   | \x3134323332 | 1111 | \x3939393939 | 13:23:21
+   1 | Jim   | \x3134323332 | 1112 | \x3939393939 | 13:23:21
    2 | James | \x3535353535 | 2222 | \x3838383838 | 15:55:55
 (2 rows)
 

--- a/output/ogr_fdw.source
+++ b/output/ogr_fdw.source
@@ -117,14 +117,14 @@ CREATE TABLE bytea_local (
   happened time
 );
 INSERT INTO bytea_local VALUES 
-  (1, 'Jim', '14232'::bytea, 8142312312, '99999'::bytea, '13:23:21'::time);
+  (1, 'Jim', '14232'::bytea, 1111, '99999'::bytea, '13:23:21'::time);
 INSERT INTO bytea_local VALUES 
-  (2, 'James', '55555'::bytea, 9124231543, '88888'::bytea, '15:55:55'::time);
+  (2, 'James', '55555'::bytea, 2222, '88888'::bytea, '15:55:55'::time);
 SELECT * FROM bytea_local;
- fid | name  |     geom     |    age     |     bin      | happened 
------+-------+--------------+------------+--------------+----------
-   1 | Jim   | \x3134323332 | 8142312312 | \x3939393939 | 13:23:21
-   2 | James | \x3535353535 | 9124231543 | \x3838383838 | 15:55:55
+ fid | name  |     geom     | age  |     bin      | happened 
+-----+-------+--------------+------+--------------+----------
+   1 | Jim   | \x3134323332 | 1111 | \x3939393939 | 13:23:21
+   2 | James | \x3535353535 | 2222 | \x3838383838 | 15:55:55
 (2 rows)
 
   
@@ -137,10 +137,10 @@ CREATE FOREIGN TABLE bytea_fdw (
   happened time
 ) SERVER pgserver OPTIONS (layer 'bytea_local');
 SELECT * FROM bytea_fdw;
- fid | name  |     geom     |    age     |     bin      | happened 
------+-------+--------------+------------+--------------+----------
-   1 | Jim   | \x3134323332 | 8142312312 | \x3939393939 | 13:23:21
-   2 | James | \x3535353535 | 9124231543 | \x3838383838 | 15:55:55
+ fid | name  |     geom     | age  |     bin      | happened 
+-----+-------+--------------+------+--------------+----------
+   1 | Jim   | \x3134323332 | 1111 | \x3939393939 | 13:23:21
+   2 | James | \x3535353535 | 2222 | \x3838383838 | 15:55:55
 (2 rows)
 
 EXPLAIN VERBOSE SELECT * FROM bytea_fdw;

--- a/output/ogr_fdw.source
+++ b/output/ogr_fdw.source
@@ -102,3 +102,51 @@ SELECT "natural" FROM ntrl."natural";
  land
 (2 rows)
 
+------------------------------------------------
+CREATE SERVER pgserver
+  FOREIGN DATA WRAPPER ogr_fdw
+  OPTIONS (
+    datasource 'PG:dbname=contrib_regression host=localhost',
+    format 'PostgreSQL' );
+CREATE TABLE bytea_local (
+  fid integer primary key,
+  name varchar,
+  geom bytea,
+  age bigint,
+  bin bytea,
+  happened time
+);
+INSERT INTO bytea_local VALUES 
+  (1, 'Jim', '14232'::bytea, 8142312312, '99999'::bytea, '13:23:21'::time);
+INSERT INTO bytea_local VALUES 
+  (2, 'James', '55555'::bytea, 9124231543, '88888'::bytea, '15:55:55'::time);
+SELECT * FROM bytea_local;
+ fid | name  |     geom     |    age     |     bin      | happened 
+-----+-------+--------------+------------+--------------+----------
+   1 | Jim   | \x3134323332 | 8142312312 | \x3939393939 | 13:23:21
+   2 | James | \x3535353535 | 9124231543 | \x3838383838 | 15:55:55
+(2 rows)
+
+  
+CREATE FOREIGN TABLE bytea_fdw (
+  fid integer,
+  name text,
+  geom bytea,
+  age bigint,
+  bin bytea,
+  happened time
+) SERVER pgserver OPTIONS (layer 'bytea_local');
+SELECT * FROM bytea_fdw;
+ fid | name  |     geom     |    age     |     bin      | happened 
+-----+-------+--------------+------------+--------------+----------
+   1 | Jim   | \x3134323332 | 8142312312 | \x3939393939 | 13:23:21
+   2 | James | \x3535353535 | 9124231543 | \x3838383838 | 15:55:55
+(2 rows)
+
+EXPLAIN VERBOSE SELECT * FROM bytea_fdw;
+                                 QUERY PLAN                                  
+-----------------------------------------------------------------------------
+ Foreign Scan on public.bytea_fdw  (cost=25.00..1025.00 rows=1000 width=116)
+   Output: fid, name, geom, age, bin, happened
+(2 rows)
+


### PR DESCRIPTION
This should address #74, by accepting the first columns of an FDW table as geometries, if the OGR source has geometries to match to, but pushing subsequent fields down into the field matching regime. So, in a table with multiple bytea columns, the first N will become geom mappings and the remainder field mappings.