### PR TITLE
Unify code between ogr_fdw_info and IMPORT

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,7 @@ PG_CPPFLAGS += $(GDAL_CFLAGS)
 LIBS += $(GDAL_LIBS)
 SHLIB_LINK := $(LIBS)
 
+# order matters, file first, import last
 REGRESS = file pgsql import
 
 PGXS := $(shell $(PG_CONFIG) --pgxs)

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # ogr_fdw/Makefile
 
 MODULE_big = ogr_fdw
-OBJS = ogr_fdw.o ogr_fdw_deparse.o ogr_fdw_common.o
+OBJS = ogr_fdw.o ogr_fdw_deparse.o ogr_fdw_common.o stringbuffer_pg.o
 EXTENSION = ogr_fdw
 DATA = ogr_fdw--1.0.sql
 
@@ -33,11 +33,14 @@ include $(PGXS)
 CFLAGS = $(GDAL_CFLAGS)
 LIBS = $(GDAL_LIBS)
 
-ogr_fdw_info$(X): ogr_fdw_info.o ogr_fdw_common.o
+ogr_fdw_info$(X): ogr_fdw_info.o ogr_fdw_common.o stringbuffer.o
 	$(CC) $(CFLAGS) -o $@ $? $(LIBS)
 
+stringbuffer_pg.o: stringbuffer.c stringbuffer.h
+	$(CC) $(CFLAGS) -D USE_PG_MEM -c -o $@ $<
+
 clean-exe:
-	rm -f ogr_fdw_info$(X) ogr_fdw_info.o
+	rm -f ogr_fdw_info$(X) ogr_fdw_info.o stringbuffer.o
 
 install-exe: all
 	$(INSTALL_PROGRAM) ogr_fdw_info$(X) '$(DESTDIR)$(bindir)'

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ CFLAGS = $(GDAL_CFLAGS)
 LIBS = $(GDAL_LIBS)
 
 ogr_fdw_info$(X): ogr_fdw_info.o ogr_fdw_common.o stringbuffer.o
-	$(CC) $(CFLAGS) -o $@ $? $(LIBS)
+	$(CC) $(CFLAGS) -o $@ $^ $(LIBS)
 
 stringbuffer_pg.o: stringbuffer.c stringbuffer.h
 	$(CC) $(CFLAGS) -D USE_PG_MEM -c -o $@ $<

--- a/input/file.source
+++ b/input/file.source
@@ -79,15 +79,17 @@ CREATE SERVER csvserver
     datasource '@abs_srcdir@/data/no_geom.csv',
     format 'CSV' );
 
-DROP SCHEMA IF EXISTS csv;
-CREATE SCHEMA csv;
-IMPORT FOREIGN SCHEMA ogr_all 
-  FROM SERVER csvserver 
-  INTO csv;
+CREATE FOREIGN TABLE no_geom (
+  fid bigint,
+  name varchar,
+  age varchar,
+  value varchar
+) SERVER csvserver
+OPTIONS (layer 'no_geom');
 
 SELECT c.* 
   FROM generate_series(1,4) g 
-  JOIN csv.no_geom c 
+  JOIN no_geom c 
   ON (c.fid = g.g);
 
 ------------------------------------------------

--- a/input/import.source
+++ b/input/import.source
@@ -6,6 +6,8 @@ IMPORT FOREIGN SCHEMA ogr_all
   LIMIT TO (n2launder) 
   FROM SERVER myserver 
   INTO imp1;
+
+\d imp1.n2launder
   
 SELECT * FROM imp1.n2launder WHERE fid = 0;
 
@@ -17,6 +19,8 @@ IMPORT FOREIGN SCHEMA ogr_all
   LIMIT TO ("natural") 
   FROM SERVER myserver 
   INTO imp2;
+
+\d imp2."natural"
 
 SELECT "natural" FROM imp2."natural";
 

--- a/input/import.source
+++ b/input/import.source
@@ -21,4 +21,3 @@ IMPORT FOREIGN SCHEMA ogr_all
 SELECT "natural" FROM imp2."natural";
 
 ------------------------------------------------
-

--- a/ogr_fdw.c
+++ b/ogr_fdw.c
@@ -2269,7 +2269,6 @@ ogrImportForeignSchema(ImportForeignSchemaStmt *stmt, Oid serverOid)
 	import_all = streq(stmt->remote_schema, "ogr_all");
 
 	/* Make connection to server */
-	memset(&ogr, 0, sizeof(OgrConnection));
 	server = GetForeignServer(serverOid);
 	ogr = ogrGetConnectionFromServer(serverOid, false);
 

--- a/ogr_fdw.h
+++ b/ogr_fdw.h
@@ -8,6 +8,8 @@
  *-------------------------------------------------------------------------
  */
 
+#ifndef _OGR_FDW_H
+#define _OGR_FDW_H 1
 
 /*
  * PostgreSQL
@@ -56,10 +58,6 @@
 /* GDAL/OGR includes and compat */
 #include "ogr_fdw_gdal.h"
 #include "ogr_fdw_common.h"
-
-/* Utility macros for string equality */
-#define streq(s1,s2) (strcmp((s1),(s2)) == 0)
-#define strcaseeq(s1,s2) (strcasecmp((s1),(s2)) == 0)
 
 typedef enum 
 {
@@ -165,8 +163,8 @@ typedef struct OgrFdwModifyState
 /* Shared function signatures */
 bool ogrDeparse(StringInfo buf, PlannerInfo *root, RelOptInfo *foreignrel, List *exprs, List **param);
 
-void ogrDeparseStringLiteral(StringInfo buf, const char *val);
 
 /* Shared global value of the Geometry OId */
 extern Oid GEOMETRYOID;
 
+#endif /* _OGR_FDW_H */

--- a/ogr_fdw_common.c
+++ b/ogr_fdw_common.c
@@ -182,8 +182,11 @@ ogrGeomTypeToPgGeomType(stringbuffer_t *buf, OGRwkbGeometryType gtype)
 			CPLError(CE_Failure, CPLE_AssertionFailed, "Cannot handle OGR geometry type '%d'", gtype);
 	}
 
+#if GDAL_VERSION_MAJOR >= 2 
 	if ( wkbHasZ(gtype) )
 		stringbuffer_append(buf, "Z");
+#endif
+	
 #if GDAL_VERSION_MAJOR >= 2 && GDAL_VERSION_MINOR >= 1
 	if ( wkbHasM(gtype) )
 		stringbuffer_append(buf, "M");

--- a/ogr_fdw_common.c
+++ b/ogr_fdw_common.c
@@ -184,8 +184,10 @@ ogrGeomTypeToPgGeomType(stringbuffer_t *buf, OGRwkbGeometryType gtype)
 
 #if GDAL_VERSION_MAJOR >= 2 
 	if ( wkbHasZ(gtype) )
-		stringbuffer_append(buf, "Z");
+#else
+	if ( gtype & wkb25DBit )
 #endif
+		stringbuffer_append(buf, "Z");
 	
 #if GDAL_VERSION_MAJOR >= 2 && GDAL_VERSION_MINOR >= 1
 	if ( wkbHasM(gtype) )

--- a/ogr_fdw_common.c
+++ b/ogr_fdw_common.c
@@ -184,8 +184,10 @@ ogrGeomTypeToPgGeomType(stringbuffer_t *buf, OGRwkbGeometryType gtype)
 
 	if ( wkbHasZ(gtype) )
 		stringbuffer_append(buf, "Z");
+#if GDAL_VERSION_MAJOR >= 2 && GDAL_VERSION_MINOR >= 1
 	if ( wkbHasM(gtype) )
 		stringbuffer_append(buf, "M");
+#endif
 
 	return;
 }

--- a/ogr_fdw_common.c
+++ b/ogr_fdw_common.c
@@ -8,10 +8,48 @@
  *-------------------------------------------------------------------------
  */
 
+#include "ogr_fdw_gdal.h"
 #include "ogr_fdw_common.h"
+#include "stringbuffer.h"
+
+/* Prototype for function that must be defined in PostgreSQL (it is) */
+/* and in ogr_fdw_info (it is) */
+const char * quote_identifier(const char *ident);
+
+
+/*
+ * Append a SQL string literal representing "val" to buf.
+ */
+static void
+ogrDeparseStringLiteral(stringbuffer_t *buf, const char *val)
+{
+	const char *valptr;
+
+	/*
+	 * Rather than making assumptions about the remote server's value of
+	 * standard_conforming_strings, always use E'foo' syntax if there are any
+	 * backslashes.  This will fail on remote servers before 8.1, but those
+	 * are long out of support.
+	 */
+	if ( strchr(val, '\\') != NULL )
+	{
+		stringbuffer_append_char(buf, 'E');
+	}
+	stringbuffer_append_char(buf, '\'');
+	for ( valptr = val; *valptr; valptr++ )
+	{
+		char ch = *valptr;
+		if ( ch == '\'' || ch == '\\' )
+		{
+			stringbuffer_append_char(buf, ch);
+		}
+		stringbuffer_append_char(buf, ch);
+	}
+	stringbuffer_append_char(buf, '\'');
+}
 
 void
-ogrStringLaunder (char *str)
+ogrStringLaunder(char *str)
 {
 	int i, j = 0;
 	char tmp[STR_MAX_LEN];
@@ -47,3 +85,265 @@ ogrStringLaunder (char *str)
 	strncpy(str, tmp, STR_MAX_LEN);
 	
 }
+
+static char *
+ogrTypeToPgType(OGRFieldDefnH ogr_fld)
+{
+	OGRFieldType ogr_type = OGR_Fld_GetType(ogr_fld);
+	switch(ogr_type)
+	{
+		case OFTInteger:
+#if GDAL_VERSION_MAJOR >= 2
+			if( OGR_Fld_GetSubType(ogr_fld) == OFSTBoolean )
+				return "boolean";
+			else
+#endif
+				return "integer";
+		case OFTReal:
+			return "real";
+		case OFTString:
+			return "varchar";
+		case OFTBinary:
+			return "bytea";
+		case OFTDate:
+			return "date";
+		case OFTTime:
+			return "time";
+		case OFTDateTime:
+			return "timestamp";
+		case OFTIntegerList:
+			return "integer[]";
+		case OFTRealList:
+			return "real[]";
+		case OFTStringList:
+			return "varchar[]";
+#if GDAL_VERSION_MAJOR >= 2
+		case OFTInteger64:
+			return "bigint";
+#endif
+		default:
+			CPLError(CE_Failure, CPLE_AssertionFailed, 
+			         "unsupported GDAL type '%s'", 
+			         OGR_GetFieldTypeName(ogr_type));
+			return NULL;
+	}
+	return NULL;
+}
+
+static void
+ogrGeomTypeToPgGeomType(stringbuffer_t *buf, OGRwkbGeometryType gtype)
+{
+	switch(wkbFlatten(gtype))
+	{
+	    case wkbUnknown:
+			stringbuffer_append(buf, "Geometry");
+			break;
+	    case wkbPoint:
+			stringbuffer_append(buf, "Point");
+			break;
+		case wkbLineString:
+			stringbuffer_append(buf, "LineString");
+			break;
+		case wkbPolygon:
+			stringbuffer_append(buf, "Polygon");
+			break;
+		case wkbMultiPoint:
+			stringbuffer_append(buf, "MultiPoint");
+			break;
+		case wkbMultiLineString:
+			stringbuffer_append(buf, "MultiLineString");
+			break;
+		case wkbMultiPolygon:
+			stringbuffer_append(buf, "MultiPolygon");
+			break;
+		case wkbGeometryCollection:
+			stringbuffer_append(buf, "GeometryCollection");
+			break;
+#if GDAL_VERSION_MAJOR >= 2
+		case wkbCircularString:
+			stringbuffer_append(buf, "CircularString");
+			break;
+		case wkbCompoundCurve:
+			stringbuffer_append(buf, "CompoundCurve");
+			break;
+		case wkbCurvePolygon:
+			stringbuffer_append(buf, "CurvePolygon");
+			break;
+		case wkbMultiCurve:
+			stringbuffer_append(buf, "MultiCurve");
+			break;
+		case wkbMultiSurface:
+			stringbuffer_append(buf, "MultiSurface");
+			break;
+#endif
+		case wkbNone:
+			CPLError(CE_Failure, CPLE_AssertionFailed, "Cannot handle OGR geometry type wkbNone");
+		default:
+			CPLError(CE_Failure, CPLE_AssertionFailed, "Cannot handle OGR geometry type '%d'", gtype);
+	}
+
+	if ( wkbHasZ(gtype) )
+		stringbuffer_append(buf, "Z");
+	if ( wkbHasM(gtype) )
+		stringbuffer_append(buf, "M");
+
+	return;
+}
+
+static OGRErr
+ogrColumnNameToSQL (const char *ogrcolname, const char *pgtype, int launder_column_names, stringbuffer_t *buf)
+{
+	char pgcolname[STR_MAX_LEN];
+	strncpy(pgcolname, ogrcolname, STR_MAX_LEN);
+	ogrStringLaunder(pgcolname);
+
+	if ( launder_column_names )
+	{
+		stringbuffer_aprintf(buf, ",\n  %s %s", quote_identifier(pgcolname), pgtype);
+		if ( ! strcaseeq(pgcolname, ogrcolname) )
+			stringbuffer_aprintf(buf, " OPTIONS (column_name '%s')", ogrcolname);
+	}
+	else
+	{
+		/* OGR column is PgSQL compliant, we're all good */
+		if ( streq(pgcolname, ogrcolname) )
+			stringbuffer_aprintf(buf, ",\n  %s %s", quote_identifier(ogrcolname), pgtype);
+		/* OGR is mixed case or non-compliant, we need to quote it */
+		else
+			stringbuffer_aprintf(buf, ",\n  \"%s\" %s", ogrcolname, pgtype);
+	}
+	return OGRERR_NONE;
+}
+
+OGRErr
+ogrLayerToSQL (const OGRLayerH ogr_lyr, const char *fwd_server, 
+			   int launder_table_names, int launder_column_names,
+			   int use_postgis_geometry, stringbuffer_t *buf)
+{
+	int geom_field_count, i;
+	char table_name[STR_MAX_LEN];
+	OGRFeatureDefnH ogr_fd = OGR_L_GetLayerDefn(ogr_lyr);
+	stringbuffer_t gbuf;
+	
+	stringbuffer_init(&gbuf);
+
+	if ( ! ogr_fd )
+	{
+		CPLError(CE_Failure, CPLE_AssertionFailed, "unable to get OGRFeatureDefnH from OGRLayerH");
+		return OGRERR_FAILURE;
+	}
+
+#if GDAL_VERSION_MAJOR >= 2 || GDAL_VERSION_MINOR >= 11
+	geom_field_count = OGR_FD_GetGeomFieldCount(ogr_fd);
+#else
+	geom_field_count = (OGR_L_GetGeomType(ogr_lyr) != wkbNone);
+#endif
+	
+	/* Process table name */
+	strncpy(table_name, OGR_L_GetName(ogr_lyr), STR_MAX_LEN);
+	if (launder_table_names)
+		ogrStringLaunder(table_name);
+	
+	/* Create table */
+	stringbuffer_aprintf(buf, "CREATE FOREIGN TABLE %s (\n", quote_identifier(table_name));
+	
+	/* For now, every table we auto-create will have a FID */
+	stringbuffer_append(buf, "  fid bigint");
+	
+	/* Handle all geometry columns in the OGR source */
+	for ( i = 0; i < geom_field_count; i++ )
+	{
+		int srid = 0;
+#if GDAL_VERSION_MAJOR >= 2 || GDAL_VERSION_MINOR >= 11
+		OGRGeomFieldDefnH gfld = OGR_FD_GetGeomFieldDefn(ogr_fd, i);
+		OGRwkbGeometryType gtype = OGR_GFld_GetType(gfld);
+		const char *geomfldname = OGR_GFld_GetNameRef(gfld);
+		OGRSpatialReferenceH gsrs = OGR_GFld_GetSpatialRef(gfld);
+#else
+		OGRwkbGeometryType gtype = OGR_FD_GetGeomType(ogr_fd);
+		const char *geomfldname = "geom";
+		OGRSpatialReferenceH gsrs = OGR_L_GetSpatialRef(ogr_lyr);
+#endif
+		/* Skip geometry type we cannot handle */
+		if ( gtype == wkbNone )
+			continue;
+
+		/* Clear out our geometry type buffer */
+		stringbuffer_clear(&gbuf);
+
+		/* PostGIS geometry type has lots of complex stuff */
+		if ( use_postgis_geometry )
+		{	
+			/* Add geometry type info */
+			stringbuffer_append(&gbuf, "Geometry(");
+			ogrGeomTypeToPgGeomType(&gbuf, gtype);
+			
+			/* See if we have an EPSG code to work with */
+			if ( gsrs )
+			{
+				const char *charAuthType;
+				const char *charSrsCode;
+				OSRAutoIdentifyEPSG(gsrs);
+				charAuthType = OSRGetAttrValue(gsrs, "AUTHORITY", 0);
+				charSrsCode = OSRGetAttrValue(gsrs, "AUTHORITY", 1);
+				if ( charAuthType && strcaseeq(charAuthType, "EPSG") &&
+				     charSrsCode && atoi(charSrsCode) > 0 )
+				{
+					srid = atoi(charSrsCode);
+				}
+			}
+		
+			/* Add EPSG number, if figured it out */
+			if ( srid )
+			{
+				stringbuffer_aprintf(&gbuf, ",%d)", srid);
+			}
+			else
+			{
+				stringbuffer_append(&gbuf, ")");
+			}
+		}
+		/* Bytea is simple */
+		else
+		{
+			stringbuffer_append(&gbuf, "bytea");
+		}
+	
+		/* Use geom field name if we have it */
+		if ( geomfldname && strlen(geomfldname) > 0 )
+		{
+			ogrColumnNameToSQL(geomfldname, stringbuffer_getstring(&gbuf), launder_column_names, buf);
+		}
+		/* Or a numbered generic name if we don't */
+		else if ( geom_field_count > 1 )
+		{
+			stringbuffer_aprintf(buf, ",\n  geom%d %s", i, stringbuffer_getstring(&gbuf));
+		}
+		/* Or just a generic name */
+		else
+		{
+			stringbuffer_aprintf(buf, ",\n  geom %s", stringbuffer_getstring(&gbuf));
+		}
+	}
+
+	/* Write out attribute fields */
+	for ( i = 0; i < OGR_FD_GetFieldCount(ogr_fd); i++ )
+	{
+		OGRFieldDefnH ogr_fld = OGR_FD_GetFieldDefn(ogr_fd, i);
+		ogrColumnNameToSQL(OGR_Fld_GetNameRef(ogr_fld), 
+		                   ogrTypeToPgType(ogr_fld), 
+		                   launder_column_names, buf);
+	}
+
+	/*
+	 * Add server name and layer-level options.  We specify remote
+	 * layer name as option
+	 */
+	stringbuffer_aprintf(buf, "\n) SERVER %s\nOPTIONS (", quote_identifier(fwd_server));
+	stringbuffer_append(buf, "layer ");
+	ogrDeparseStringLiteral(buf, OGR_L_GetName(ogr_lyr));
+	stringbuffer_append(buf, ");\n");
+	
+	return OGRERR_NONE;
+}
+

--- a/ogr_fdw_common.h
+++ b/ogr_fdw_common.h
@@ -8,9 +8,26 @@
  *-------------------------------------------------------------------------
  */
 
+#ifndef _OGR_FDW_COMMON_H
+#define _OGR_FDW_COMMON_H 1
+
 #include <string.h>
 #include <ctype.h>
+#include "stringbuffer.h"
 
 #define STR_MAX_LEN 256
 
-void ogrStringLaunder (char *str);
+/* Utility macros for string equality */
+#define streq(s1,s2) (strcmp((s1),(s2)) == 0)
+#define strcaseeq(s1,s2) (strcasecmp((s1),(s2)) == 0)
+
+
+/* Re-write a string in place with laundering rules */
+void ogrStringLaunder(char *str);
+
+OGRErr ogrLayerToSQL (const OGRLayerH ogr_lyr,
+               const char *fwd_server, int launder_table_names, int launder_column_names,
+			   int use_postgis_geometry, stringbuffer_t *buf);
+
+
+#endif /* _OGR_FDW_COMMON_H */

--- a/ogr_fdw_deparse.c
+++ b/ogr_fdw_deparse.c
@@ -526,32 +526,5 @@ ogrDeparse(StringInfo buf, PlannerInfo *root, RelOptInfo *foreignrel, List *expr
 }
 
 
-/*
- * Append a SQL string literal representing "val" to buf.
- */
-void
-ogrDeparseStringLiteral(StringInfo buf, const char *val)
-{
-	const char *valptr;
-
-	/*
-	 * Rather than making assumptions about the remote server's value of
-	 * standard_conforming_strings, always use E'foo' syntax if there are any
-	 * backslashes.  This will fail on remote servers before 8.1, but those
-	 * are long out of support.
-	 */
-	if (strchr(val, '\\') != NULL)
-		appendStringInfoChar(buf, ESCAPE_STRING_SYNTAX);
-	appendStringInfoChar(buf, '\'');
-	for (valptr = val; *valptr; valptr++)
-	{
-		char		ch = *valptr;
-
-		if (SQL_STR_DOUBLE(ch, true))
-			appendStringInfoChar(buf, ch);
-		appendStringInfoChar(buf, ch);
-	}
-	appendStringInfoChar(buf, '\'');
-}
 
 

--- a/ogr_fdw_gdal.h
+++ b/ogr_fdw_gdal.h
@@ -1,12 +1,23 @@
+
+#ifndef _OGR_FDW_GDAL_H
+#define _OGR_FDW_GDAL_H 1
+
 /*
  * OGR library API
  */
 #include "gdal.h"
 #include "ogr_api.h"
+#include "ogr_srs_api.h"
 #include "cpl_error.h"
 #include "cpl_string.h"
 
-/* Support for GDAL 1.X */
+/* 
+ * As far as possible code is GDAL2 compliant, and these
+ * mappings are used to convert to GDAL1-style function
+ * names. For GDALDatasetH opening, there are specific
+ * code blocks to handle version differences between 
+ * GDALOpenEx() and OGROpen()
+ */
 #if GDAL_VERSION_MAJOR < 2
 
 /* Redefine variable types */
@@ -27,3 +38,5 @@
 #define GDALDatasetTestCapability(ds,cap) OGR_Dr_TestCapability(ds,cap)
 
 #endif /* GDAL 1 support */
+
+#endif /* _OGR_FDW_GDAL_H */

--- a/output/file.source
+++ b/output/file.source
@@ -87,16 +87,16 @@ CREATE SERVER csvserver
   OPTIONS (
     datasource '@abs_srcdir@/data/no_geom.csv',
     format 'CSV' );
-DROP SCHEMA IF EXISTS csv;
-NOTICE:  schema "csv" does not exist, skipping
-CREATE SCHEMA csv;
-IMPORT FOREIGN SCHEMA ogr_all 
-  FROM SERVER csvserver 
-  INTO csv;
-NOTICE:  Number of tables to be created 1
+CREATE FOREIGN TABLE no_geom (
+  fid bigint,
+  name varchar,
+  age varchar,
+  value varchar
+) SERVER csvserver
+OPTIONS (layer 'no_geom');
 SELECT c.* 
   FROM generate_series(1,4) g 
-  JOIN csv.no_geom c 
+  JOIN no_geom c 
   ON (c.fid = g.g);
  fid |  name   | age | value 
 -----+---------+-----+-------

--- a/output/import.source
+++ b/output/import.source
@@ -5,6 +5,19 @@ IMPORT FOREIGN SCHEMA ogr_all
   FROM SERVER myserver 
   INTO imp1;
 NOTICE:  Number of tables to be created 1
+\d imp1.n2launder
+                    Foreign table "imp1.n2launder"
+  Column   |       Type        | Modifiers |        FDW Options        
+-----------+-------------------+-----------+---------------------------
+ fid       | bigint            |           | 
+ geom      | bytea             |           | 
+ n2ame     | character varying |           | (column_name '2ame')
+ age       | integer           |           | 
+ height    | real              |           | 
+ b_rthdate | date              |           | (column_name 'b-rthdate')
+Server: myserver
+FDW Options: (layer '2launder')
+
   
 SELECT * FROM imp1.n2launder WHERE fid = 0;
  fid |                     geom                     | n2ame | age | height | b_rthdate  
@@ -19,6 +32,16 @@ IMPORT FOREIGN SCHEMA ogr_all
   FROM SERVER myserver 
   INTO imp2;
 NOTICE:  Number of tables to be created 1
+\d imp2."natural"
+             Foreign table "imp2.natural"
+ Column  |       Type        | Modifiers | FDW Options 
+---------+-------------------+-----------+-------------
+ fid     | bigint            |           | 
+ id      | real              |           | 
+ natural | character varying |           | 
+Server: myserver
+FDW Options: (layer 'natural')
+
 SELECT "natural" FROM imp2."natural";
  natural 
 ---------

--- a/stringbuffer.c
+++ b/stringbuffer.c
@@ -1,0 +1,367 @@
+/*-------------------------------------------------------------------------
+ *
+ * stringbuffer.c
+ *		  simple stringbuffer
+ *
+ * Copyright (c) 2009, Paul Ramsey <pramsey@cleverelephant.ca>
+ * Copyright (c) 2002 Thamer Alharbash
+ *
+ *-------------------------------------------------------------------------
+ */
+
+#include "stringbuffer.h"
+
+#ifdef USE_PG_MEM
+
+void * palloc(size_t sz);
+void pfree(void *ptr);
+void * repalloc(void *ptr, size_t sz);
+
+#define malloc(sz) palloc(sz)
+#define free(ptr) pfree(ptr)
+#define realloc(ptr,sz) repalloc(ptr,sz)
+
+#endif
+
+/**
+* Allocate a new stringbuffer_t. Use stringbuffer_destroy to free.
+*/
+stringbuffer_t* 
+stringbuffer_create(void)
+{
+	return stringbuffer_create_with_size(STRINGBUFFER_STARTSIZE);
+}
+
+static void
+stringbuffer_init_with_size(stringbuffer_t *s, size_t size)
+{
+	s->str_start = malloc(size);
+	s->str_end = s->str_start;
+	s->capacity = size;
+	memset(s->str_start, 0, size);
+}
+
+void
+stringbuffer_release(stringbuffer_t *s)
+{
+	if ( s->str_start ) free(s->str_start);
+}
+
+void
+stringbuffer_init(stringbuffer_t *s)
+{
+	stringbuffer_init_with_size(s, STRINGBUFFER_STARTSIZE);
+}
+
+/**
+* Allocate a new stringbuffer_t. Use stringbuffer_destroy to free.
+*/
+stringbuffer_t* 
+stringbuffer_create_with_size(size_t size)
+{
+	stringbuffer_t *s;
+
+	s = malloc(sizeof(stringbuffer_t));
+	stringbuffer_init_with_size(s, size);
+	return s;
+}
+
+/**
+* Free the stringbuffer_t and all memory managed within it.
+*/
+void 
+stringbuffer_destroy(stringbuffer_t *s)
+{
+	stringbuffer_release(s);
+	if ( s ) free(s);
+}
+
+/**
+* Reset the stringbuffer_t. Useful for starting a fresh string
+* without the expense of freeing and re-allocating a new
+* stringbuffer_t.
+*/
+void 
+stringbuffer_clear(stringbuffer_t *s)
+{
+	s->str_start[0] = '\0';
+	s->str_end = s->str_start;
+}
+
+/**
+* If necessary, expand the stringbuffer_t internal buffer to accomodate the
+* specified additional size.
+*/
+static inline void 
+stringbuffer_makeroom(stringbuffer_t *s, size_t size_to_add)
+{
+	size_t current_size = (s->str_end - s->str_start);
+	size_t capacity = s->capacity;
+	size_t required_size = current_size + size_to_add;
+
+	while (capacity < required_size)
+		capacity *= 2;
+
+	if ( capacity > s->capacity )
+	{
+		s->str_start = realloc(s->str_start, capacity);
+		s->capacity = capacity;
+		s->str_end = s->str_start + current_size;
+	}
+}
+
+/**
+* Return the last character in the buffer.
+*/
+char 
+stringbuffer_lastchar(stringbuffer_t *s)
+{
+	if( s->str_end == s->str_start ) 
+		return 0;
+	
+	return *(s->str_end - 1);
+}
+
+/**
+* Append the specified string to the stringbuffer_t.
+*/
+void 
+stringbuffer_append(stringbuffer_t *s, const char *a)
+{
+	int alen = strlen(a); /* Length of string to append */
+	int alen0 = alen + 1; /* Length including null terminator */
+	stringbuffer_makeroom(s, alen0);
+	memcpy(s->str_end, a, alen0);
+	s->str_end += alen;
+}
+
+/**
+* Append the specified character to the stringbuffer_t.
+*/
+void 
+stringbuffer_append_char(stringbuffer_t *s, char c)
+{
+	stringbuffer_makeroom(s, 1);
+	*(s->str_end) = c; /* add char */
+	s->str_end += 1;
+	*(s->str_end) = 0; /* null terminate */
+}
+
+/**
+* Returns a reference to the internal string being managed by
+* the stringbuffer. The current string will be null-terminated
+* within the internal string.
+*/
+const char* 
+stringbuffer_getstring(stringbuffer_t *s)
+{
+	return s->str_start;
+}
+
+/**
+* Returns a newly allocated string large enough to contain the
+* current state of the string. Caller is responsible for
+* freeing the return value.
+*/
+char* 
+stringbuffer_getstringcopy(stringbuffer_t *s)
+{
+	size_t size = (s->str_end - s->str_start) + 1;
+	char *str = malloc(size);
+	memcpy(str, s->str_start, size);
+	str[size - 1] = '\0';
+	return str;
+}
+
+/**
+* Returns the length of the current string, not including the
+* null terminator (same behavior as strlen()).
+*/
+int 
+stringbuffer_getlength(stringbuffer_t *s)
+{
+	return (s->str_end - s->str_start);
+}
+
+/**
+* Clear the stringbuffer_t and re-start it with the specified string.
+*/
+void 
+stringbuffer_set(stringbuffer_t *s, const char *str)
+{
+	stringbuffer_clear(s);
+	stringbuffer_append(s, str);
+}
+
+/**
+* Copy the contents of src into dst.
+*/
+void 
+stringbuffer_copy(stringbuffer_t *dst, stringbuffer_t *src)
+{
+	stringbuffer_set(dst, stringbuffer_getstring(src));
+}
+
+/**
+* Appends a formatted string to the current string buffer,
+* using the format and argument list provided. Returns -1 on error,
+* check errno for reasons, documented in the printf man page.
+*/
+static int 
+stringbuffer_avprintf(stringbuffer_t *s, const char *fmt, va_list ap)
+{
+	int maxlen = (s->capacity - (s->str_end - s->str_start));
+	int len = 0; /* Length of the output */
+	va_list ap2;
+
+	/* Make a copy of the variadic arguments, in case we need to print twice */
+	/* Print to our buffer */
+	va_copy(ap2, ap);
+	len = vsnprintf(s->str_end, maxlen, fmt, ap2);
+	va_end(ap2);
+
+	/* Propogate errors up */
+	if ( len < 0 ) 
+		#if defined(__MINGW64_VERSION_MAJOR)
+		len = _vscprintf(fmt, ap2);/**Assume windows flaky vsnprintf that returns -1 if initial buffer to small and add more space **/
+		#else
+		return len;
+		#endif
+
+	/* We didn't have enough space! */
+	/* Either Unix vsnprint returned write length larger than our buffer */
+	/*     or Windows vsnprintf returned an error code. */
+	if ( len >= maxlen )
+	{
+		stringbuffer_makeroom(s, len + 1);
+		maxlen = (s->capacity - (s->str_end - s->str_start));
+
+		/* Try to print a second time */
+		len = vsnprintf(s->str_end, maxlen, fmt, ap);
+
+		/* Printing error? Error! */
+		if ( len < 0 ) return len;
+		/* Too long still? Error! */
+		if ( len >= maxlen ) return -1;
+	}
+
+	/* Move end pointer forward and return. */
+	s->str_end += len;
+	return len;
+}
+
+/**
+* Appends a formatted string to the current string buffer,
+* using the format and argument list provided.
+* Returns -1 on error, check errno for reasons,
+* as documented in the printf man page.
+*/
+int 
+stringbuffer_aprintf(stringbuffer_t *s, const char *fmt, ...)
+{
+	int r;
+	va_list ap;
+	va_start(ap, fmt);
+	r = stringbuffer_avprintf(s, fmt, ap);
+	va_end(ap);
+	return r;
+}
+
+/**
+* Trims whitespace off the end of the stringbuffer. Returns
+* the number of characters trimmed.
+*/
+int 
+stringbuffer_trim_trailing_white(stringbuffer_t *s)
+{
+	char *ptr = s->str_end;
+	int dist = 0;
+	
+	/* Roll backwards until we hit a non-space. */
+	while( ptr > s->str_start )
+	{	
+		ptr--;
+		if( (*ptr == ' ') || (*ptr == '\t') )
+		{
+			continue;
+		}
+		else
+		{
+			ptr++;
+			dist = s->str_end - ptr;
+			*ptr = '\0';
+			s->str_end = ptr;
+			return dist;
+		}
+	}
+	return dist;	
+}
+
+/**
+* Trims zeroes off the end of the last number in the stringbuffer.
+* The number has to be the very last thing in the buffer. Only the
+* last number will be trimmed. Returns the number of characters
+* trimmed.
+* 
+* eg: 1.22000 -> 1.22
+*     1.0 -> 1
+*     0.0 -> 0
+*/
+int 
+stringbuffer_trim_trailing_zeroes(stringbuffer_t *s)
+{
+	char *ptr = s->str_end;
+	char *decimal_ptr = NULL;
+	int dist;
+	
+	if ( s->str_end - s->str_start < 2) 
+		return 0;
+
+	/* Roll backwards to find the decimal for this number */
+	while( ptr > s->str_start )
+	{	
+		ptr--;
+		if ( *ptr == '.' )
+		{
+			decimal_ptr = ptr;
+			break;
+		}
+		if ( (*ptr >= '0') && (*ptr <= '9' ) )
+			continue;
+		else
+			break;
+	}
+
+	/* No decimal? Nothing to trim! */
+	if ( ! decimal_ptr )
+		return 0;
+	
+	ptr = s->str_end;
+	
+	/* Roll backwards again, with the decimal as stop point, trimming contiguous zeroes */
+	while( ptr >= decimal_ptr )
+	{
+		ptr--;
+		if ( *ptr == '0' )
+			continue;
+		else
+			break;
+	}
+	
+	/* Huh, we get anywhere. Must not have trimmed anything. */
+	if ( ptr == s->str_end )
+		return 0;
+
+	/* If we stopped at the decimal, we want to null that out. 
+	   It we stopped on a numeral, we want to preserve that, so push the 
+	   pointer forward one space. */
+	if ( *ptr != '.' )
+		ptr++;
+
+	/* Add null terminator re-set the end of the stringbuffer. */
+	*ptr = '\0';
+	dist = s->str_end - ptr;
+	s->str_end = ptr;
+	return dist;
+}
+

--- a/stringbuffer.h
+++ b/stringbuffer.h
@@ -1,0 +1,48 @@
+/*-------------------------------------------------------------------------
+ *
+ * stringbuffer.h
+ *		  simple stringbuffer
+ *
+ * Copyright (c) 2009, Paul Ramsey <pramsey@cleverelephant.ca>
+ * Copyright (c) 2002 Thamer Alharbash
+ *
+ *-------------------------------------------------------------------------
+ */
+
+#ifndef _STRINGBUFFER_H
+#define _STRINGBUFFER_H 1
+
+#include <stdlib.h>
+#include <stdarg.h>
+#include <string.h>
+#include <stdio.h>
+
+#define STRINGBUFFER_STARTSIZE 128
+
+typedef struct
+{
+	size_t capacity;
+	char *str_end;
+	char *str_start;
+}
+stringbuffer_t;
+
+extern stringbuffer_t *stringbuffer_create_with_size(size_t size);
+extern stringbuffer_t *stringbuffer_create(void);
+extern void stringbuffer_init(stringbuffer_t *s);
+extern void stringbuffer_release(stringbuffer_t *s);
+extern void stringbuffer_destroy(stringbuffer_t *sb);
+extern void stringbuffer_clear(stringbuffer_t *sb);
+void stringbuffer_set(stringbuffer_t *sb, const char *s);
+void stringbuffer_copy(stringbuffer_t *sb, stringbuffer_t *src);
+extern void stringbuffer_append(stringbuffer_t *sb, const char *s);
+extern void stringbuffer_append_char(stringbuffer_t *s, char c);
+extern int stringbuffer_aprintf(stringbuffer_t *sb, const char *fmt, ...);
+extern const char *stringbuffer_getstring(stringbuffer_t *sb);
+extern char *stringbuffer_getstringcopy(stringbuffer_t *sb);
+extern int stringbuffer_getlength(stringbuffer_t *sb);
+extern char stringbuffer_lastchar(stringbuffer_t *s);
+extern int stringbuffer_trim_trailing_white(stringbuffer_t *s);
+extern int stringbuffer_trim_trailing_zeroes(stringbuffer_t *s);
+
+#endif /* _STRINGBUFFER_H */


### PR DESCRIPTION
Bring the code for writing out a SQL statement into a common module, and call from both sides. This allows improvements like `column_name` aliasing, and better geometry column handling (geometry type and SRID) to be shared between both calling points.