### PR TITLE
Fix typo conect -> connect.

### DIFF
--- a/ogr_fdw_info.c
+++ b/ogr_fdw_info.c
@@ -154,7 +154,7 @@ ogrListLayers(const char *source)
 	
 	if ( ! ogr_ds )
 	{
-		CPLError(CE_Failure, CPLE_AppDefined, "Could not conect to source '%s'", source);
+		CPLError(CE_Failure, CPLE_AppDefined, "Could not connect to source '%s'", source);
 		return OGRERR_FAILURE; 
 	}
 


### PR DESCRIPTION
This was spotted by lintian during a Debian package build.