### PR TITLE
Fix for issue #128

### DIFF
--- a/input/pgsql.source
+++ b/input/pgsql.source
@@ -9,6 +9,7 @@ CREATE TABLE bytea_local (
   geom bytea,
   name varchar,
   age bigint,
+  size integer,
   value float8,
   num numeric(6,2),
   dt date,
@@ -20,10 +21,12 @@ CREATE TABLE bytea_local (
 
 ----------------------------------------------------------------------
 
-INSERT INTO bytea_local (name, geom, age, value, num, dt, tm, dttm, varch, yn) 
-  VALUES ('Jim', '14232'::bytea, 23, 4.3, 5.5, '2010-10-10'::date, '13:23:21'::time, '2010-10-10 13:23:21'::timestamp, 'this', 'y' );
-INSERT INTO bytea_local (name, geom, age, value, num, dt, tm, dttm, varch, yn) 
-  VALUES ('Marvin', '55555'::bytea, 34, 5.4, 10.13, '2011-11-11'::date, '15:21:45'::time, '2011-11-11 15:21:45'::timestamp, 'that', 'n' );
+INSERT INTO bytea_local (name, geom, age, size, value, num, dt, tm, dttm, varch, yn)
+  VALUES ('Jim', '14232'::bytea, 23, 1, 4.3, 5.5, '2010-10-10'::date, '13:23:21'::time, '2010-10-10 13:23:21'::timestamp, 'this', 'y' );
+INSERT INTO bytea_local (name, geom, age, size, value, num, dt, tm, dttm, varch, yn)
+  VALUES ('Marvin', '55555'::bytea, 34, 2, 5.4, 10.13, '2011-11-11'::date, '15:21:45'::time, '2011-11-11 15:21:45'::timestamp, 'that', 'n' );
+INSERT INTO bytea_local (name, geom, age, size, value, num, dt, tm, dttm, varch, yn)
+  VALUES (NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 ----------------------------------------------------------------------
 
@@ -32,6 +35,7 @@ CREATE FOREIGN TABLE bytea_fdw (
   geom bytea,
   name varchar,
   age bigint,
+  size integer,
   value float8,
   num numeric(6,2),
   dt date,
@@ -41,7 +45,7 @@ CREATE FOREIGN TABLE bytea_fdw (
   yn char
 ) SERVER pgserver OPTIONS (layer 'bytea_local');
 
-SELECT fid, name, geom, age, value, num, dt, tm, dttm, varch, yn FROM bytea_fdw;
+SELECT fid, name, geom, age, size, value, num, dt, tm, dttm, varch, yn FROM bytea_fdw;
 
 SELECT a.name, b.name 
   FROM bytea_local a 
@@ -49,18 +53,18 @@ SELECT a.name, b.name
   USING (fid);
 
 EXPLAIN VERBOSE 
-  SELECT fid, name, geom, age, value, num, dt, tm, dttm, varch, yn 
+  SELECT fid, name, geom, age, size, value, num, dt, tm, dttm, varch, yn
   FROM bytea_fdw;
 
 ----------------------------------------------------------------------
 
-INSERT INTO bytea_fdw (name, geom, age, value, num, dt, tm, dttm, varch, yn) 
-VALUES ('Margaret', '2222'::bytea, 12, 1.4, 19.13, '2001-11-23'::date, '9:12:34'::time, '2001-02-11 09:23:11'::timestamp, 'them', 'y' ) 
-RETURNING fid, name, geom, age, value, num, dt, tm, dttm, varch, yn;
+INSERT INTO bytea_fdw (name, geom, age, size, value, num, dt, tm, dttm, varch, yn)
+VALUES ('Margaret', '2222'::bytea, 12, 5, 1.4, 19.13, '2001-11-23'::date, '9:12:34'::time, '2001-02-11 09:23:11'::timestamp, 'them', 'y' )
+RETURNING fid, name, geom, age, size, value, num, dt, tm, dttm, varch, yn;
 
-SELECT fid, name, geom, age, value, num, dt, tm, dttm, varch, yn 
+SELECT fid, name, geom, age, size, value, num, dt, tm, dttm, varch, yn
   FROM bytea_fdw
-  WHERE fid = 3;
+  WHERE fid = 4;
 
 UPDATE bytea_fdw 
   SET name = 'Maggie', num = 45.34, yn = 'n'
@@ -68,7 +72,7 @@ UPDATE bytea_fdw
 
 SELECT fid, name, num, yn
   FROM bytea_fdw
-  WHERE fid = 3;
+  WHERE fid = 4;
 
 UPDATE bytea_fdw 
   SET dt = '2089-12-13', tm = '01:23:45'
@@ -76,10 +80,10 @@ UPDATE bytea_fdw
 
 SELECT fid, dt, tm
   FROM bytea_fdw
-  WHERE fid = 3;
+  WHERE fid = 4;
 
 DELETE FROM bytea_fdw 
-  WHERE fid = 3;
+  WHERE fid = 4;
   
 SELECT a.fid, a.name, b.name 
   FROM bytea_local a 

--- a/ogr_fdw.c
+++ b/ogr_fdw.c
@@ -1579,7 +1579,7 @@ ogrFeatureToSlot(const OGRFeatureH feat, TupleTableSlot *slot, const OgrFdwExecS
 						 * For now, we go via text.
 						 */
 						const char *cstr = OGR_F_GetFieldAsString(feat, ogrfldnum);
-						if ( cstr )
+						if ( cstr && strlen(cstr) )
 						{
 							nulls[i] = false;
 							values[i] = pgDatumFromCString(cstr, pgtype, pgtypmod, pginputfunc);

--- a/output/pgsql.source
+++ b/output/pgsql.source
@@ -9,6 +9,7 @@ CREATE TABLE bytea_local (
   geom bytea,
   name varchar,
   age bigint,
+  size integer,
   value float8,
   num numeric(6,2),
   dt date,
@@ -18,16 +19,19 @@ CREATE TABLE bytea_local (
   yn char
 );
 ----------------------------------------------------------------------
-INSERT INTO bytea_local (name, geom, age, value, num, dt, tm, dttm, varch, yn) 
-  VALUES ('Jim', '14232'::bytea, 23, 4.3, 5.5, '2010-10-10'::date, '13:23:21'::time, '2010-10-10 13:23:21'::timestamp, 'this', 'y' );
-INSERT INTO bytea_local (name, geom, age, value, num, dt, tm, dttm, varch, yn) 
-  VALUES ('Marvin', '55555'::bytea, 34, 5.4, 10.13, '2011-11-11'::date, '15:21:45'::time, '2011-11-11 15:21:45'::timestamp, 'that', 'n' );
+INSERT INTO bytea_local (name, geom, age, size, value, num, dt, tm, dttm, varch, yn)
+  VALUES ('Jim', '14232'::bytea, 23, 1, 4.3, 5.5, '2010-10-10'::date, '13:23:21'::time, '2010-10-10 13:23:21'::timestamp, 'this', 'y' );
+INSERT INTO bytea_local (name, geom, age, size, value, num, dt, tm, dttm, varch, yn)
+  VALUES ('Marvin', '55555'::bytea, 34, 2, 5.4, 10.13, '2011-11-11'::date, '15:21:45'::time, '2011-11-11 15:21:45'::timestamp, 'that', 'n' );
+INSERT INTO bytea_local (name, geom, age, size, value, num, dt, tm, dttm, varch, yn)
+  VALUES (NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 ----------------------------------------------------------------------
 CREATE FOREIGN TABLE bytea_fdw (
   fid integer,
   geom bytea,
   name varchar,
   age bigint,
+  size integer,
   value float8,
   num numeric(6,2),
   dt date,
@@ -36,12 +40,13 @@ CREATE FOREIGN TABLE bytea_fdw (
   varch char(8),
   yn char
 ) SERVER pgserver OPTIONS (layer 'bytea_local');
-SELECT fid, name, geom, age, value, num, dt, tm, dttm, varch, yn FROM bytea_fdw;
- fid |  name  |     geom     | age | value |  num  |     dt     |    tm    |           dttm           |  varch   | yn 
------+--------+--------------+-----+-------+-------+------------+----------+--------------------------+----------+----
-   1 | Jim    | \x3134323332 |  23 |   4.3 |  5.50 | 10-10-2010 | 13:23:21 | Sun Oct 10 13:23:21 2010 | this     | y
-   2 | Marvin | \x3535353535 |  34 |   5.4 | 10.13 | 11-11-2011 | 15:21:45 | Fri Nov 11 15:21:45 2011 | that     | n
-(2 rows)
+SELECT fid, name, geom, age, size, value, num, dt, tm, dttm, varch, yn FROM bytea_fdw;
+ fid |  name  |     geom     | age | size | value |  num  |     dt     |    tm    |           dttm           |  varch   | yn 
+-----+--------+--------------+-----+------+-------+-------+------------+----------+--------------------------+----------+----
+   1 | Jim    | \x3134323332 |  23 |    1 |   4.3 |  5.50 | 10-10-2010 | 13:23:21 | Sun Oct 10 13:23:21 2010 | this     | y
+   2 | Marvin | \x3535353535 |  34 |    2 |   5.4 | 10.13 | 11-11-2011 | 15:21:45 | Fri Nov 11 15:21:45 2011 | that     | n
+   3 |        |              |     |      |       |       |            |          |                          |          | 
+(3 rows)
 
 SELECT a.name, b.name 
   FROM bytea_local a 
@@ -51,32 +56,33 @@ SELECT a.name, b.name
 --------+--------
  Jim    | Jim
  Marvin | Marvin
-(2 rows)
+        | 
+(3 rows)
 
 EXPLAIN VERBOSE 
-  SELECT fid, name, geom, age, value, num, dt, tm, dttm, varch, yn 
+  SELECT fid, name, geom, age, size, value, num, dt, tm, dttm, varch, yn
   FROM bytea_fdw;
                                  QUERY PLAN                                  
 -----------------------------------------------------------------------------
- Foreign Scan on public.bytea_fdw  (cost=25.00..1025.00 rows=1000 width=162)
-   Output: fid, name, geom, age, value, num, dt, tm, dttm, varch, yn
+ Foreign Scan on public.bytea_fdw  (cost=25.00..1025.00 rows=1000 width=166)
+   Output: fid, name, geom, age, size, value, num, dt, tm, dttm, varch, yn
 (2 rows)
 
 ----------------------------------------------------------------------
-INSERT INTO bytea_fdw (name, geom, age, value, num, dt, tm, dttm, varch, yn) 
-VALUES ('Margaret', '2222'::bytea, 12, 1.4, 19.13, '2001-11-23'::date, '9:12:34'::time, '2001-02-11 09:23:11'::timestamp, 'them', 'y' ) 
-RETURNING fid, name, geom, age, value, num, dt, tm, dttm, varch, yn;
- fid |   name   |    geom    | age | value |  num  |     dt     |    tm    |           dttm           |  varch   | yn 
------+----------+------------+-----+-------+-------+------------+----------+--------------------------+----------+----
-   3 | Margaret | \x32323232 |  12 |   1.4 | 19.13 | 11-23-2001 | 09:12:34 | Sun Feb 11 09:23:11 2001 | them     | y
+INSERT INTO bytea_fdw (name, geom, age, size, value, num, dt, tm, dttm, varch, yn)
+VALUES ('Margaret', '2222'::bytea, 12, 5, 1.4, 19.13, '2001-11-23'::date, '9:12:34'::time, '2001-02-11 09:23:11'::timestamp, 'them', 'y' )
+RETURNING fid, name, geom, age, size, value, num, dt, tm, dttm, varch, yn;
+ fid |   name   |    geom    | age | size | value |  num  |     dt     |    tm    |           dttm           |  varch   | yn 
+-----+----------+------------+-----+------+-------+-------+------------+----------+--------------------------+----------+----
+   4 | Margaret | \x32323232 |  12 |    5 |   1.4 | 19.13 | 11-23-2001 | 09:12:34 | Sun Feb 11 09:23:11 2001 | them     | y
 (1 row)
 
-SELECT fid, name, geom, age, value, num, dt, tm, dttm, varch, yn 
+SELECT fid, name, geom, age, size, value, num, dt, tm, dttm, varch, yn
   FROM bytea_fdw
-  WHERE fid = 3;
- fid |   name   |    geom    | age | value |  num  |     dt     |    tm    |           dttm           |  varch   | yn 
------+----------+------------+-----+-------+-------+------------+----------+--------------------------+----------+----
-   3 | Margaret | \x32323232 |  12 |   1.4 | 19.13 | 11-23-2001 | 09:12:34 | Sun Feb 11 09:23:11 2001 | them     | y
+  WHERE fid = 4;
+ fid |   name   |    geom    | age | size | value |  num  |     dt     |    tm    |           dttm           |  varch   | yn 
+-----+----------+------------+-----+------+-------+-------+------------+----------+--------------------------+----------+----
+   4 | Margaret | \x32323232 |  12 |    5 |   1.4 | 19.13 | 11-23-2001 | 09:12:34 | Sun Feb 11 09:23:11 2001 | them     | y
 (1 row)
 
 UPDATE bytea_fdw 
@@ -84,10 +90,10 @@ UPDATE bytea_fdw
   WHERE age = 12;
 SELECT fid, name, num, yn
   FROM bytea_fdw
-  WHERE fid = 3;
+  WHERE fid = 4;
  fid |  name  |  num  | yn 
 -----+--------+-------+----
-   3 | Maggie | 45.34 | n
+   4 | Maggie | 45.34 | n
 (1 row)
 
 UPDATE bytea_fdw 
@@ -95,14 +101,14 @@ UPDATE bytea_fdw
   WHERE num = 45.34;
 SELECT fid, dt, tm
   FROM bytea_fdw
-  WHERE fid = 3;
+  WHERE fid = 4;
  fid |     dt     |    tm    
 -----+------------+----------
-   3 | 12-13-2089 | 01:23:45
+   4 | 12-13-2089 | 01:23:45
 (1 row)
 
 DELETE FROM bytea_fdw 
-  WHERE fid = 3;
+  WHERE fid = 4;
   
 SELECT a.fid, a.name, b.name 
   FROM bytea_local a 
@@ -112,6 +118,7 @@ SELECT a.fid, a.name, b.name
 -----+--------+--------
    1 | Jim    | Jim
    2 | Marvin | Marvin
-(2 rows)
+   3 |        | 
+(3 rows)
 
   


### PR DESCRIPTION
It seems that some formats don't return NULL values as an "unset" OGR field but instead return an empty string. In the contact of an OGR integer, we'll continue an empty string to be a NULL.