### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This implementation currently has the following limitations:
 
 ## Download
 * Windows
-  * Via [Stackbuilder](https://www.postgresql.org/download/windows/)
+  * Via [Stackbuilder](https://www.postgresql.org/download/windows/) (part of PostGIS Bundle)
 * Linux
   * [Arch Linux](https://aur.archlinux.org/packages/pgsql-ogr-fdw/)
   * [Ubuntu](https://launchpad.net/ubuntu/+source/pgsql-ogr-fdw)


### PR DESCRIPTION
Stackbuilder is probably not sufficient, to say because ogr_fdw isn't a separate install.  I bundle it with PostGIS installer since it relies on GDAL and I can only have one GDAL install per PostgreSQL instance. (so I added a note it's part of PostGIS Bundle) so people don't get confused looking for it separately.