### PR TITLE
ogr_fdw_info enhancements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,7 @@ REGRESS_OPTS = --encoding=UTF8
 
 PG_CPPFLAGS += $(GDAL_CFLAGS)
 LIBS += $(GDAL_LIBS)
+
 SHLIB_LINK := $(LIBS)
 
 PGXS := $(shell $(PG_CONFIG) --pgxs)

--- a/README.md
+++ b/README.md
@@ -60,20 +60,20 @@ Use the `ogr_fdw_info` tool to read an OGR data source and output a server and t
 
 		> ogr_fdw_info -s /tmp/test -l pt_two
 
-		CREATE SERVER myserver
+		CREATE SERVER "myserver"
 			FOREIGN DATA WRAPPER ogr_fdw
 			OPTIONS (
 				datasource '/tmp/test',
 				format 'ESRI Shapefile' );
 
-		CREATE FOREIGN TABLE pt_two (
+		CREATE FOREIGN TABLE "pt_two" (
 			fid integer,
-			geom geometry(Point, 4326),
-			name varchar,
-			age integer,
-			height real,
-			birthdate date )
-			SERVER myserver
+			"geom" geometry(Point, 4326),
+			"name" varchar,
+			"age" integer,
+			"height" real,
+			"birthdate" date )
+			SERVER "myserver"
 			OPTIONS (layer 'pt_two');
 
 Copy the `CREATE SERVER` and `CREATE FOREIGN SERVER` SQL commands into the database and you'll have your foreign table definition.

--- a/ogr_fdw.c
+++ b/ogr_fdw.c
@@ -2959,6 +2959,7 @@ ogrImportForeignSchema(ImportForeignSchemaStmt* stmt, Oid serverOid)
 
 			err = ogrLayerToSQL(ogr_lyr,
 			                    quote_identifier(server->servername),
+								NULL,
 			                    launder_table_names,
 			                    launder_column_names,
 			                    ogrGetGeometryOid() != BYTEAOID,

--- a/ogr_fdw_common.c
+++ b/ogr_fdw_common.c
@@ -283,7 +283,7 @@ ogrLayerToSQL (const OGRLayerH ogr_lyr, const char *fdw_server, const char *fdw_
 	}
 
 	/* Create table */
-	stringbuffer_aprintf(buf, "CREATE FOREIGN TABLE %s (\n", table_name);
+	stringbuffer_aprintf(buf, "CREATE FOREIGN TABLE \"%s\" (\n", table_name);
 
 	/* For now, every table we auto-create will have a FID */
 	stringbuffer_append(buf, "  fid bigint");

--- a/ogr_fdw_common.h
+++ b/ogr_fdw_common.h
@@ -25,8 +25,8 @@
 /* Re-write a string in place with laundering rules */
 void ogrStringLaunder(char *str);
 
-OGRErr ogrLayerToSQL (const OGRLayerH ogr_lyr, const char *fwd_server,
-                      int launder_table_names, int launder_column_names,
+OGRErr ogrLayerToSQL (const OGRLayerH ogr_lyr,
+                      const char *fwd_server, const char *fwd_table_name, int launder_table_names, int launder_column_names,
                       int use_postgis_geometry, stringbuffer_t *buf);
 
 #endif /* _OGR_FDW_COMMON_H */


### PR DESCRIPTION
Hi

I have been carrying these changes manually for a while so I thought it's about time to see if you might be interested in merging them.

We use ogr_fdw_info as part of an automated process for loading client spreadsheets (XLSX) but the current version was not quite suitable for the following reasons.

1. Unable to specify output server name.
2. Unable to specify output table name.
3. Unable to use worksheet index rather than layer.
4. Unable to add config options to the foreign data wrapper
5. Column names were not quoted leading to the possibility of invalid SQL output
6. Column names were not limited to a max number of characters leading to the program crashing if, for example, the client had forgotten to add column names and the column contains a lot of raw data.
7. No exit code to let the calling program know if there has been an OGR Error

I would be happy to make any amendments if you are happy to merge with changes.

Many thanks

Kieran
 