### PR TITLE
ogr_fdw_info Enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,20 +58,20 @@ Layers:
 
 # ogr_fdw_info -s /tmp/test -l pt_two
 
-CREATE SERVER myserver
+CREATE SERVER "myserver"
   FOREIGN DATA WRAPPER ogr_fdw
   OPTIONS (
     datasource '/tmp/test',
     format 'ESRI Shapefile' );
 
-CREATE FOREIGN TABLE pt_two (
+CREATE FOREIGN TABLE "pt_two" (
   fid integer,
-  geom geometry(Point, 4326),
-  name varchar,
-  age integer,
-  height real,
-  birthdate date )
-  SERVER myserver
+  "geom" geometry(Point, 4326),
+  "name" varchar,
+  "age" integer,
+  "height" real,
+  "birthdate" date )
+  SERVER "myserver"
   OPTIONS (layer 'pt_two');
 ```
 

--- a/ogr_fdw.c
+++ b/ogr_fdw.c
@@ -2961,6 +2961,7 @@ ogrImportForeignSchema(ImportForeignSchemaStmt* stmt, Oid serverOid)
 			                    quote_identifier(server->servername),
 			                    launder_table_names,
 			                    launder_column_names,
+			                    NULL,
 			                    ogrGetGeometryOid() != BYTEAOID,
 			                    &buf
 			                   );

--- a/ogr_fdw_common.c
+++ b/ogr_fdw_common.c
@@ -80,8 +80,8 @@ ogrStringLaunder(char *str)
 		tmp[j++] = c;
 
 		/* Avoid mucking with data beyond the end of our stack-allocated strings */
-		if ( j >= NAMEDATALEN )
-			j = NAMEDATALEN - 1;
+		if ( j >= NAMEDATALEN - 1)
+			break;
 	}
 	strncpy(str, tmp, NAMEDATALEN);
 

--- a/ogr_fdw_common.c
+++ b/ogr_fdw_common.c
@@ -11,6 +11,7 @@
 #include "ogr_fdw_gdal.h"
 #include "ogr_fdw_common.h"
 #include "stringbuffer.h"
+#include "pg_config_manual.h"
 
 /* Prototype for function that must be defined in PostgreSQL (it is) */
 /* and in ogr_fdw_info (it is) */
@@ -52,8 +53,8 @@ void
 ogrStringLaunder(char *str)
 {
 	int i, j = 0;
-	char tmp[MAX_IDENTIFIER_LEN];
-	memset(tmp, 0, MAX_IDENTIFIER_LEN);
+	char tmp[NAMEDATALEN];
+	memset(tmp, 0, NAMEDATALEN);
 
 	for(i = 0; str[i]; i++)
 	{
@@ -79,10 +80,10 @@ ogrStringLaunder(char *str)
 		tmp[j++] = c;
 
 		/* Avoid mucking with data beyond the end of our stack-allocated strings */
-		if ( j >= MAX_IDENTIFIER_LEN )
-			j = MAX_IDENTIFIER_LEN - 1;
+		if ( j >= NAMEDATALEN )
+			j = NAMEDATALEN - 1;
 	}
-	strncpy(str, tmp, MAX_IDENTIFIER_LEN);
+	strncpy(str, tmp, NAMEDATALEN);
 
 }
 
@@ -220,8 +221,8 @@ ogrGeomTypeToPgGeomType(stringbuffer_t *buf, OGRwkbGeometryType gtype)
 static OGRErr
 ogrColumnNameToSQL (const char *ogrcolname, const char *pgtype, int launder_column_names, stringbuffer_t *buf)
 {
-	char pgcolname[MAX_IDENTIFIER_LEN];
-	strncpy(pgcolname, ogrcolname, MAX_IDENTIFIER_LEN);
+	char pgcolname[NAMEDATALEN];
+	strncpy(pgcolname, ogrcolname, NAMEDATALEN);
 	ogrStringLaunder(pgcolname);
 
 
@@ -255,7 +256,7 @@ ogrLayerToSQL (const OGRLayerH ogr_lyr, const char *fdw_server,
 			   int use_postgis_geometry, stringbuffer_t *buf)
 {
 	int geom_field_count, i;
-	char table_name[MAX_IDENTIFIER_LEN];
+	char table_name[NAMEDATALEN];
 	OGRFeatureDefnH ogr_fd = OGR_L_GetLayerDefn(ogr_lyr);
 	stringbuffer_t gbuf;
 
@@ -275,13 +276,13 @@ ogrLayerToSQL (const OGRLayerH ogr_lyr, const char *fdw_server,
 
 	/* Process table name */
 	if (fdw_table_name == NULL) {
-		strncpy(table_name, OGR_L_GetName(ogr_lyr), MAX_IDENTIFIER_LEN);
+		strncpy(table_name, OGR_L_GetName(ogr_lyr), NAMEDATALEN);
 
 		if (launder_table_names)
 			ogrStringLaunder(table_name);
 	}
 	else {
-		strncpy(table_name, fdw_table_name, MAX_IDENTIFIER_LEN);
+		strncpy(table_name, fdw_table_name, NAMEDATALEN);
 	}
 
 	/* Create table */
@@ -369,7 +370,7 @@ ogrLayerToSQL (const OGRLayerH ogr_lyr, const char *fdw_server,
 	/* Write out attribute fields */
 	for ( i = 0; i < OGR_FD_GetFieldCount(ogr_fd); i++ )
 	{
-		char pgtype[MAX_IDENTIFIER_LEN];
+		char pgtype[NAMEDATALEN];
 		OGRFieldDefnH ogr_fld = OGR_FD_GetFieldDefn(ogr_fd, i);
 		ogrTypeToPgType(ogr_fld, pgtype, sizeof(pgtype));
 		ogrColumnNameToSQL(OGR_Fld_GetNameRef(ogr_fld), pgtype, launder_column_names, buf);

--- a/ogr_fdw_common.h
+++ b/ogr_fdw_common.h
@@ -15,6 +15,7 @@
 #include <ctype.h>
 #include "stringbuffer.h"
 
+#define MAX_IDENTIFIER_LEN 63+1
 #define STR_MAX_LEN 256
 
 /* Utility macros for string equality */
@@ -27,6 +28,7 @@ void ogrStringLaunder(char *str);
 
 OGRErr ogrLayerToSQL (const OGRLayerH ogr_lyr, const char *fwd_server,
                       int launder_table_names, int launder_column_names,
+                      const char *fdw_table_name,
                       int use_postgis_geometry, stringbuffer_t *buf);
 
 #endif /* _OGR_FDW_COMMON_H */

--- a/ogr_fdw_common.h
+++ b/ogr_fdw_common.h
@@ -15,7 +15,6 @@
 #include <ctype.h>
 #include "stringbuffer.h"
 
-#define MAX_IDENTIFIER_LEN 63+1
 #define STR_MAX_LEN 256
 
 /* Utility macros for string equality */

--- a/ogr_fdw_info.c
+++ b/ogr_fdw_info.c
@@ -46,13 +46,15 @@ char identifier[NAMEDATALEN+3];
 const char*
 quote_identifier(const char* ident)
 {
+	int len = (int)MIN(strlen(ident), NAMEDATALEN - 1);
+
 	if (reserved_word(ident))
 	{
-		sprintf(identifier,"\"%*s\"", (int)MIN(strlen(ident), NAMEDATALEN), ident);
+		sprintf(identifier,"\"%*s\"", len, ident);
 	}
 	else
 	{
-		sprintf(identifier,"%*s", (int)MIN(strlen(ident), NAMEDATALEN), ident);
+		sprintf(identifier,"%*s", len, ident);
 	}
   return identifier;
 }

--- a/ogr_fdw_info.c
+++ b/ogr_fdw_info.c
@@ -20,20 +20,32 @@
 
 static void usage();
 static OGRErr ogrListLayers(const char* source);
-static OGRErr ogrGenerateSQL(const char* source, const char* layer);
+static OGRErr ogrFindLayer(const char* source, int layerno, const char** layer);
+static OGRErr ogrGenerateSQL(const char* server, const char* layer, const char* table, const char* source, const char* options);
 
-#define STR_MAX_LEN 256
+static char *
+strupr(char* str)
+{
+  for (int i = 0; i < strlen(str); i++) {
+    str[i] = toupper(str[i]);
+  }
 
+  return str;
+}
 
 /* Define this no-op here, so that code */
 /* in the ogr_fdw_common module works */
 const char* quote_identifier(const char* ident);
 
+char identifier[MAX_IDENTIFIER_LEN+3];
+
 const char*
 quote_identifier(const char* ident)
 {
-	return ident;
+  sprintf(identifier,"\"%*s\"", (int)MIN(strlen(ident), MAX_IDENTIFIER_LEN), ident);
+  return identifier;
 }
+char config_options[STR_MAX_LEN] = {0};
 
 
 static void
@@ -84,10 +96,16 @@ static void
 usage()
 {
 	printf(
-	    "usage: ogr_fdw_info -s <ogr datasource> -l <ogr layer>\n"
-	    "	   ogr_fdw_info -s <ogr datasource>\n"
-	    "	   ogr_fdw_info -f\n"
-	    "\n");
+		"usage: ogr_fdw_info -s <ogr datasource> -l <ogr layer name> -i <ogr layer index (numeric)> -t <output table name> -n <output server name> -o <config options>\n"
+		"       ogr_fdw_info -s <ogr datasource>\n"
+		"usage: ogr_fdw_info -f\n"
+		"       Show what input file formats are supported.\n"
+		"\n");
+	printf(
+		"note (1): You can specify either -l (layer name) or -i (layer index) if you specify both -l will be used\n"
+		"note (2): config options are specified as a comma deliminated list without the OGR_<driver>_ prefix\n"
+		"so OGR_XLSX_HEADERS = FORCE OGR_XLSX_FIELD_TYPES = STRING would become:\n\"HEADERS = FORCE,FIELD_TYPES = STRING\""
+		"\n");
 	exit(0);
 }
 
@@ -95,7 +113,9 @@ int
 main(int argc, char** argv)
 {
 	int ch;
-	char* source = NULL, *layer = NULL;
+	char* source = NULL;
+	const char* layer = NULL, *server = NULL, *table = NULL, *options = NULL;
+	int layer_index = -1;
 	OGRErr err = OGRERR_NONE;
 
 	/* If no options are specified, display usage */
@@ -104,7 +124,7 @@ main(int argc, char** argv)
 		usage();
 	}
 
-	while ((ch = getopt(argc, argv, "h?s:l:f")) != -1)
+	while ((ch = getopt(argc, argv, "h?s:l:f:t:n:i:o:")) != -1)
 	{
 		switch (ch)
 		{
@@ -117,6 +137,18 @@ main(int argc, char** argv)
 		case 'f':
 			formats();
 			break;
+		case 't':
+			table = optarg;
+			break;
+		case 'n':
+			server = optarg;
+			break;
+		case 'i':
+			layer_index = atoi(optarg) - 1;
+			break;
+		case 'o':
+			options = optarg;
+			break;
 		case '?':
 		case 'h':
 		default:
@@ -125,13 +157,21 @@ main(int argc, char** argv)
 		}
 	}
 
-	if (source && ! layer)
+	if (source && ! layer && layer_index == -1)
 	{
 		err = ogrListLayers(source);
 	}
-	else if (source && layer)
+	else if (source && (layer || layer_index > -1))
 	{
-		err = ogrGenerateSQL(source, layer);
+		if (! layer)
+		{
+			err = ogrFindLayer(source, layer_index, &layer);
+		}
+
+		if (err == OGRERR_NONE)
+		{
+			err = ogrGenerateSQL(server, layer, table, source, options);
+		}
 	}
 	else if (! source && ! layer)
 	{
@@ -140,11 +180,12 @@ main(int argc, char** argv)
 
 	if (err != OGRERR_NONE)
 	{
-		// printf("OGR Error: %s\n\n", CPLGetLastErrorMsg());
+		printf("OGR Error: %s\n\n", CPLGetLastErrorMsg());
+    exit(2);
 	}
 
 	OGRCleanupAll();
-	exit(0);
+	exit(1);
 }
 
 static OGRErr
@@ -187,14 +228,17 @@ ogrListLayers(const char* source)
 }
 
 static OGRErr
-ogrGenerateSQL(const char* source, const char* layer)
+ogrGenerateSQL(const char* server, const char* layer, const char* table, const char* source, const char* options)
 {
 	OGRErr err;
 	GDALDatasetH ogr_ds = NULL;
 	GDALDriverH ogr_dr = NULL;
 	OGRLayerH ogr_lyr = NULL;
-	char server_name[STR_MAX_LEN];
+	char server_name[MAX_IDENTIFIER_LEN];
 	stringbuffer_t buf;
+
+	char **option_iter;
+	char **option_list;
 
 	GDALAllRegister();
 
@@ -213,12 +257,35 @@ ogrGenerateSQL(const char* source, const char* layer)
 	}
 
 	if (! ogr_dr)
-	{
 		ogr_dr = GDALGetDatasetDriver(ogr_ds);
-	}
 
-	/* There should be a nicer way to do this */
-	strcpy(server_name, "myserver");
+	strcpy(server_name, server == NULL ? "myserver" : server);
+
+  if (options != NULL) {
+    char *p = strtok((char*)options, ",");
+    char option[MAX_IDENTIFIER_LEN];
+
+    while (p != NULL) {
+      while( isspace((unsigned char) *p) ) { ++p; }
+      sprintf(option, "OGR_%s_%s ", GDALGetDriverShortName(ogr_dr), strupr(p));
+      strcat(config_options, option);
+      p = strtok(NULL, ",");
+    }
+  }
+
+	option_list = CSLTokenizeString(config_options);
+	for ( option_iter = option_list; option_iter && *option_iter; option_iter++ )
+	{
+		char *key;
+		const char *value;
+		value = CPLParseNameValue(*option_iter, &key);
+		if (! (key && value))
+			CPLError(CE_Failure, CPLE_AppDefined, "bad config option string '%s'", config_options);
+
+		CPLSetConfigOption(key, value);
+		CPLFree(key);
+	}
+	CSLDestroy( option_list );
 
 	ogr_lyr = GDALDatasetGetLayerByName(ogr_ds, layer);
 	if (! ogr_lyr)
@@ -231,15 +298,17 @@ ogrGenerateSQL(const char* source, const char* layer)
 	printf("\nCREATE SERVER %s\n"
 	       "  FOREIGN DATA WRAPPER ogr_fdw\n"
 	       "  OPTIONS (\n"
-	       "	datasource '%s',\n"
-	       "	format '%s' );\n",
-	       server_name, source, GDALGetDriverShortName(ogr_dr));
+	       "    datasource '%s',\n"
+	       "    format '%s', );\n"
+	       "    config_options '%s');\n",
+	       quote_identifier(server_name), source, GDALGetDriverShortName(ogr_dr), config_options);
 
 	stringbuffer_init(&buf);
 	err = ogrLayerToSQL(ogr_lyr,
 	                    server_name,
 	                    TRUE, /* launder table names */
 	                    TRUE, /* launder column names */
+	                    table,/* output table name */
 	                    TRUE, /* use postgis geometry */
 	                    &buf);
 
@@ -255,3 +324,59 @@ ogrGenerateSQL(const char* source, const char* layer)
 	return OGRERR_NONE;
 }
 
+static OGRErr
+ogrFindLayer(const char *source, int layerno, const char** layer)
+{
+	GDALDatasetH ogr_ds = NULL;
+	int i;
+	char **option_iter;
+	char **option_list;
+
+	GDALAllRegister();
+
+	option_list = CSLTokenizeString(config_options);
+	for (option_iter = option_list; option_iter && *option_iter; option_iter++)
+	{
+		char *key;
+		const char *value;
+		value = CPLParseNameValue(*option_iter, &key);
+		if (! (key && value))
+			CPLError(CE_Failure, CPLE_AppDefined, "bad config option string '%s'", config_options);
+
+		CPLSetConfigOption(key, value);
+		CPLFree(key);
+	}
+	CSLDestroy(option_list);
+
+
+	#if GDAL_VERSION_MAJOR < 2
+	ogr_ds = OGROpen(source, FALSE, NULL);
+	#else
+	ogr_ds = GDALOpenEx(source,
+	                    GDAL_OF_VECTOR | GDAL_OF_READONLY,
+	                    NULL, NULL, NULL);
+	#endif
+
+	if (! ogr_ds)
+	{
+		CPLError(CE_Failure, CPLE_AppDefined, "Could not connect to source '%s'", source);
+		return OGRERR_FAILURE;
+	}
+
+	for (i = 0; i < GDALDatasetGetLayerCount(ogr_ds); i++)
+	{
+		if (i == layerno) {
+			OGRLayerH ogr_lyr = GDALDatasetGetLayer(ogr_ds, i);
+			if (! ogr_lyr)
+			{
+				return OGRERR_FAILURE;
+			}
+			*layer = OGR_L_GetName(ogr_lyr);
+			return OGRERR_NONE;
+		}
+	}
+
+	GDALClose(ogr_ds);
+
+	return OGRERR_FAILURE;
+}


### PR DESCRIPTION
Hi

Thanks for looking at the patch. I've reformatted it to reduce the noise (sorry, it was based on an earlier version before you ran astyle on it) and reworked it a little. I have added some more explanation below

We use ogr_fdw_info as part of an automated process for loading client spreadsheets (XLSX) but the current version was not quite suitable for the following reasons.

Unable to specify output server name.
Unable to specify output table name.
Unable to use ogr layer index rather than layer.
Unable to add config options to the foreign data wrapper
Column names were not quoted leading to the possibility of invalid SQL output. The existing code allowed reserved words to be used as column names, this creates problems when trying to run the output in postgresql.
No exit code to let the calling program know if there has been an OGR Error

In addition I have introduced MAX_IDENTIFIER_LEN to be clearer about creating identifiers that are no longer than the maximum length allowed in postgresql

I would be happy to make any amendments if you are happy to merge with changes.

Many thanks

Kieran
