### PR TITLE
Add 'character_encoding' server option

### DIFF
--- a/README.md
+++ b/README.md
@@ -461,3 +461,17 @@ SERVER odbc_latin1
 ```
 
 
+CREATE SERVER server_latin1
+  FOREIGN DATA WRAPPER ogr_fdw
+  OPTIONS (
+    datasource 'Pg:dbname=latin1 user=pramsey client_encoding=sql_ascii',
+    format 'PostgreSQL',
+    character_encoding 'LXXTIN1'
+  );
+
+CREATE FOREIGN TABLE foo (
+  name text,
+  geom geometry(Point, 4326)
+)
+SERVER server_latin1
+  OPTIONS (layer 'foo');

--- a/README.md
+++ b/README.md
@@ -437,3 +437,27 @@ To view the drivers supported by this GDAL.
 ```sql
 SELECT unnest(ogr_fdw_drivers());
 ```
+
+
+### Character Encoding
+
+To access sources that have a non-UTF-8 encoding, you may need to specify the character encoding in your server creation line. OGR FDW uses the transcoding built into PostgreSQL, and thus supports all the [encodings that PostgreSQL does](https://www.postgresql.org/docs/current/multibyte.html#CHARSET-TABLE).
+
+```sql
+CREATE SERVER odbc_latin1
+  FOREIGN DATA WRAPPER ogr_fdw
+  OPTIONS (
+    datasource 'ODBC:username@servicename',
+    format 'ODBC',
+    character_encoding 'WIN1250'
+  );
+
+CREATE FOREIGN TABLE featuretable_fdw (
+  name text,
+  geom geometry(Point, 4326)
+)
+SERVER odbc_latin1
+  OPTIONS (layer 'featuretable');
+```
+
+

--- a/README.md
+++ b/README.md
@@ -459,19 +459,3 @@ CREATE FOREIGN TABLE featuretable_fdw (
 SERVER odbc_latin1
   OPTIONS (layer 'featuretable');
 ```
-
-
-CREATE SERVER server_latin1
-  FOREIGN DATA WRAPPER ogr_fdw
-  OPTIONS (
-    datasource 'Pg:dbname=latin1 user=pramsey client_encoding=sql_ascii',
-    format 'PostgreSQL',
-    character_encoding 'LXXTIN1'
-  );
-
-CREATE FOREIGN TABLE foo (
-  name text,
-  geom geometry(Point, 4326)
-)
-SERVER server_latin1
-  OPTIONS (layer 'foo');

--- a/input/file.source
+++ b/input/file.source
@@ -91,8 +91,27 @@ CREATE FOREIGN TABLE e_1 (
   OPTIONS ( layer 'enc' );
 
 SET client_min_messages = debug1;
-SELECT * FROM e_1 WHERE fid = 1;
+SELECT fid, name FROM e_1 WHERE fid = 1;
 SET client_min_messages = notice;
+
+------------------------------------------------
+-- Using encoding option directly
+
+CREATE SERVER myserver_latin1_direct
+  FOREIGN DATA WRAPPER ogr_fdw
+  OPTIONS (
+    datasource '@abs_srcdir@/data',
+    format 'ESRI Shapefile',
+    character_encoding 'LATIN1'
+    );
+
+CREATE FOREIGN TABLE e_2 (
+  fid integer,
+  name varchar )
+  SERVER myserver_latin1_direct
+  OPTIONS ( layer 'enc' );
+
+SELECT fid, name FROM e_2 WHERE fid = 1;
 
 ------------------------------------------------
 -- Geometryless test
@@ -143,7 +162,7 @@ CREATE FOREIGN TABLE cities (
 ) SERVER "fgdbserver"
 OPTIONS (layer 'Cities');
 
-SET client_min_messages = DEBUG1;
+SET client_min_messages = LOG;
 
 SELECT fid, city_name, pop1990 FROM cities WHERE pop1990 = 17710;
 SELECT fid, city_name, pop1990 FROM cities WHERE city_name = 'Williston';

--- a/ogr_fdw.c
+++ b/ogr_fdw.c
@@ -661,9 +661,6 @@ ogrGetConnectionFromTable(Oid foreigntableid, OgrUpdateable updateable)
 	return ogr;
 }
 
-//extern int  pg_char_to_encoding(const char *name);
-//extern char *pg_server_to_any(const char *s, int len, int encoding);
-
 
 /*
  * Validate the options given to a FOREIGN DATA WRAPPER, SERVER,

--- a/ogr_fdw.c
+++ b/ogr_fdw.c
@@ -56,6 +56,7 @@ struct OgrFdwOption
 #define OPT_CONFIG_OPTIONS "config_options"
 #define OPT_OPEN_OPTIONS "open_options"
 #define OPT_UPDATEABLE "updateable"
+#define OPT_CHAR_ENCODING "character_encoding"
 
 #define OGR_FDW_FRMT_INT64	 "%lld"
 #define OGR_FDW_CAST_INT64(x)	 (long long)(x)
@@ -66,6 +67,8 @@ struct OgrFdwOption
  * ForeignServerRelationId (CREATE SERVER options)
  * UserMappingRelationId (CREATE USER MAPPING options)
  * ForeignTableRelationId (CREATE FOREIGN TABLE options)
+ *
+ * {optname, optcontext, optrequired, optfound}
  */
 static struct OgrFdwOption valid_options[] =
 {
@@ -78,6 +81,7 @@ static struct OgrFdwOption valid_options[] =
 	{OPT_DRIVER, ForeignServerRelationId, false, false},
 	{OPT_UPDATEABLE, ForeignServerRelationId, false, false},
 	{OPT_CONFIG_OPTIONS, ForeignServerRelationId, false, false},
+	{OPT_CHAR_ENCODING, ForeignServerRelationId, false, false},
 #if GDAL_VERSION_MAJOR >= 2
 	{OPT_OPEN_OPTIONS, ForeignServerRelationId, false, false},
 #endif
@@ -542,6 +546,10 @@ ogrGetConnectionFromServer(Oid foreignserverid, OgrUpdateable updateable)
 		{
 			ogr.open_options = defGetString(def);
 		}
+		if (streq(def->defname, OPT_CHAR_ENCODING))
+		{
+			ogr.char_encoding = pg_char_to_encoding(defGetString(def));
+		}
 		if (streq(def->defname, OPT_UPDATEABLE))
 		{
 			if (defGetBoolean(def))
@@ -644,10 +652,18 @@ ogrGetConnectionFromTable(Oid foreigntableid, OgrUpdateable updateable)
 		        : errhint("Does the layer exist?")
 		    ));
 	}
-	ogr.lyr_utf8 = OGR_L_TestCapability(ogr.lyr, OLCStringsAsUTF8);
+
+	if (OGR_L_TestCapability(ogr.lyr, OLCStringsAsUTF8) && !ogr.char_encoding)
+	{
+		ogr.char_encoding = PG_UTF8;
+	}
 
 	return ogr;
 }
+
+//extern int  pg_char_to_encoding(const char *name);
+//extern char *pg_server_to_any(const char *s, int len, int encoding);
+
 
 /*
  * Validate the options given to a FOREIGN DATA WRAPPER, SERVER,
@@ -665,15 +681,6 @@ ogr_fdw_validator(PG_FUNCTION_ARGS)
 	const char* source = NULL, *driver = NULL;
 	const char* config_options = NULL, *open_options = NULL;
 	OgrUpdateable updateable = OGR_UPDATEABLE_FALSE;
-
-	/* Check that the database encoding is UTF8, to match OGR internals */
-	/* TODO: Transcode inputs/outputs to the database encoding, if possibe.
-	if (GetDatabaseEncoding() != PG_UTF8)
-	{
-		elog(ERROR, "OGR FDW only works with UTF-8 databases");
-		PG_RETURN_VOID();
-	}
-	*/
 
 	/* Initialize found state to not found */
 	for (opt = valid_options; opt->optname; opt++)
@@ -1890,9 +1897,9 @@ ogrFeatureToSlot(const OGRFeatureH feat, TupleTableSlot* slot, const OgrFdwExecS
 					if (cstr_in && cstr_len > 0)
 					{
 						char* cstr_decoded;
-						if (execstate->ogr.lyr_utf8)
+						if (execstate->ogr.char_encoding)
 						{
-							cstr_decoded = pg_any_to_server(cstr_in, cstr_len, PG_UTF8);
+							cstr_decoded = pg_any_to_server(cstr_in, cstr_len, execstate->ogr.char_encoding);
 						}
 						else
 						{
@@ -1900,6 +1907,7 @@ ogrFeatureToSlot(const OGRFeatureH feat, TupleTableSlot* slot, const OgrFdwExecS
 						}
 						nulls[i] = false;
 						values[i] = pgDatumFromCString(cstr_decoded, pgtype, pgtypmod, pginputfunc);
+						pfree(cstr_decoded);
 					}
 					else
 					{

--- a/ogr_fdw.c
+++ b/ogr_fdw.c
@@ -653,7 +653,7 @@ ogrGetConnectionFromTable(Oid foreigntableid, OgrUpdateable updateable)
 		    ));
 	}
 
-	if (OGR_L_TestCapability(ogr.lyr, OLCStringsAsUTF8) && !ogr.char_encoding)
+	if (OGR_L_TestCapability(ogr.lyr, OLCStringsAsUTF8))
 	{
 		ogr.char_encoding = PG_UTF8;
 	}
@@ -1907,7 +1907,9 @@ ogrFeatureToSlot(const OGRFeatureH feat, TupleTableSlot* slot, const OgrFdwExecS
 						}
 						nulls[i] = false;
 						values[i] = pgDatumFromCString(cstr_decoded, pgtype, pgtypmod, pginputfunc);
-						pfree(cstr_decoded);
+						/* Free cstr_decoded if it is a copy */
+						if (cstr_in != cstr_decoded)
+							pfree(cstr_decoded);
 					}
 					else
 					{

--- a/ogr_fdw.h
+++ b/ogr_fdw.h
@@ -139,7 +139,7 @@ typedef struct OgrConnection
 	const char* open_options;   /* GDAL open options */
 	OgrUpdateable ds_updateable;
 	OgrUpdateable lyr_updateable;
-	bool lyr_utf8;        /* OGR layer will return UTF8 strings */
+	int char_encoding;   /* Is OGR layer UTF? Has user provided encoding open option? */
 	GDALDatasetH ds;      /* GDAL datasource handle */
 	OGRLayerH lyr;        /* OGR layer handle */
 } OgrConnection;

--- a/ogr_fdw_info.c
+++ b/ogr_fdw_info.c
@@ -28,7 +28,7 @@ static OGRErr ogrGenerateSQL(const char* server, const char* layer, const char* 
 static int reserved_word(const char* pgcolumn);
 
 static char *
-strupr(char* str)
+ogr_fdw_strupr(char* str)
 {
   for (int i = 0; i < strlen(str); i++) {
     str[i] = toupper(str[i]);
@@ -281,7 +281,7 @@ ogrGenerateSQL(const char* server, const char* layer, const char* table, const c
 
 		while (p != NULL) {
 			while( isspace((unsigned char) *p) ) { ++p; }
-			sprintf(option, "OGR_%s_%s ", GDALGetDriverShortName(ogr_dr), strupr(p));
+			sprintf(option, "OGR_%s_%s ", GDALGetDriverShortName(ogr_dr), ogr_fdw_strupr(p));
 			strcat(config_options, option);
 			p = strtok(NULL, ",");
 		}

--- a/ogr_fdw_info.c
+++ b/ogr_fdw_info.c
@@ -285,7 +285,7 @@ ogrGenerateSQL(const char* server, const char* layer, const char* table, const c
 			strcat(config_options, option);
 			p = strtok(NULL, ",");
 		}
-  }
+	}
 
 	option_list = CSLTokenizeString(config_options);
 	for ( option_iter = option_list; option_iter && *option_iter; option_iter++ )

--- a/output/file.source
+++ b/output/file.source
@@ -102,7 +102,7 @@ CREATE FOREIGN TABLE e_1 (
   SERVER myserver_latin1
   OPTIONS ( layer 'enc' );
 SET client_min_messages = debug1;
-SELECT * FROM e_1 WHERE fid = 1;
+SELECT fid, name FROM e_1 WHERE fid = 1;
 DEBUG:  GDAL config option 'SHAPE_ENCODING' set to 'LATIN1'
 DEBUG:  OGR SQL: (fid = 1)
 DEBUG:  GDAL config option 'SHAPE_ENCODING' set to 'LATIN1'
@@ -112,6 +112,26 @@ DEBUG:  GDAL config option 'SHAPE_ENCODING' set to 'LATIN1'
 (1 row)
 
 SET client_min_messages = notice;
+------------------------------------------------
+-- Using encoding option directly
+CREATE SERVER myserver_latin1_direct
+  FOREIGN DATA WRAPPER ogr_fdw
+  OPTIONS (
+    datasource '/Users/pramsey/Code/pgsql-ogr-fdw/data',
+    format 'ESRI Shapefile',
+    character_encoding 'LATIN1'
+    );
+CREATE FOREIGN TABLE e_2 (
+  fid integer,
+  name varchar )
+  SERVER myserver_latin1_direct
+  OPTIONS ( layer 'enc' );
+SELECT fid, name FROM e_2 WHERE fid = 1;
+ fid | name 
+-----+------
+   1 | Pàul
+(1 row)
+
 ------------------------------------------------
 -- Geometryless test
 CREATE SERVER csvserver
@@ -160,16 +180,14 @@ CREATE FOREIGN TABLE cities (
   popcat integer
 ) SERVER "fgdbserver"
 OPTIONS (layer 'Cities');
-SET client_min_messages = DEBUG1;
+SET client_min_messages = LOG;
 SELECT fid, city_name, pop1990 FROM cities WHERE pop1990 = 17710;
-DEBUG:  OGR SQL: (POP1990 = 17710)
  fid |  city_name   | pop1990 
 -----+--------------+---------
    9 | Port Angeles |   17710
 (1 row)
 
 SELECT fid, city_name, pop1990 FROM cities WHERE city_name = 'Williston';
-DEBUG:  OGR SQL: ("CITY_NAME" = 'Williston')
  fid | city_name | pop1990 
 -----+-----------+---------
    8 | Williston |   13131


### PR DESCRIPTION
Allows users to set the assumed server encoding, when they know it, so OGR FDW can transcode the strings on input. Can be tricky for some drivers: for example, the PgSQL client driver automatically sets the client encoding to UTF-8, which when used against a SQL_ASCII database results in a transcoding failure before the data can even reach the FDW. This should address #193.