### PR TITLE
c99 fix

### DIFF
--- a/ogr_fdw_func.c
+++ b/ogr_fdw_func.c
@@ -52,7 +52,8 @@ Datum ogr_fdw_drivers(PG_FUNCTION_ARGS)
  	arr_elems = palloc0(num_drivers * sizeof(Datum));
     get_typlenbyvalalign(elem_type, &elem_len, &elem_byval, &elem_align);
 
-	for (int i = 0; i < num_drivers; i++) {
+	int i;
+	for (i = 0; i < num_drivers; i++) {
 #if GDAL_VERSION_MAJOR <= 1
 		OGRSFDriverH hDriver = OGRGetDriver(i);
 		text *txtName = cstring_to_text(OGR_Dr_GetName(hDriver));

--- a/ogr_fdw_info.c
+++ b/ogr_fdw_info.c
@@ -30,7 +30,8 @@ static int reserved_word(const char* pgcolumn);
 static char *
 ogr_fdw_strupr(char* str)
 {
-  for (int i = 0; i < strlen(str); i++) {
+	int i;
+  for (i = 0; i < strlen(str); i++) {
     str[i] = toupper(str[i]);
   }
 
@@ -422,7 +423,8 @@ reserved_word(const char * pgcolumn)
 	"when", "where", "window", "with"
 	};
 
-	for (int i = 0; i < sizeof(reserved)/sizeof(reserved[0]); i++)
+	int i;
+	for (i = 0; i < sizeof(reserved)/sizeof(reserved[0]); i++)
 	{
 		if (strcmp(pgcolumn, reserved[i]) == 0)
 			return 1;


### PR DESCRIPTION
When running make install on Oracle Linux 9.6 the following error happens:
```
ogr_fdw_func.c: In function ‘ogr_fdw_drivers’:
ogr_fdw_func.c:55:2: error: ‘for’ loop initial declarations are only allowed in C99 mode
  for (int i = 0; i < num_drivers; i++) {
  ^
ogr_fdw_func.c:55:2: note: use option -std=c99 or -std=gnu99 to compile your code

ogr_fdw_info.c:33:3: error: ‘for’ loop initial declarations are only allowed in C99 mode
   for (int i = 0; i < strlen(str); i++) {
   ^
ogr_fdw_info.c:33:3: note: use option -std=c99 or -std=gnu99 to compile your code

ogr_fdw_info.c:425:2: error: ‘for’ loop initial declarations are only allowed in C99 mode
  for (int i = 0; i < sizeof(reserved)/sizeof(reserved[0]); i++)
  ^
ogr_fdw_info.c:425:2: note: use option -std=c99 or -std=gnu99 to compile your code
```
I updated all 3 `for` loops to have `int i;` declared before the loops in ogr_fdw_func.c and ogr_fdw_info.c and removed `int` from each loops expression.