### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,8 @@ Query away!
 ### PostgreSQL FDW
 
 Wraparound action! Handy for testing. Connect your database back to your database and watch the fur fly.
+This is only for testing, for best performance you should use postgres_fdw foreign data wrapper even when querying a PostGIS enabled database.
+
 ```sql
 CREATE TABLE apostles (
   fid serial primary key,


### PR DESCRIPTION
I think your PostgreSQL FDW example encourages bad habits. I put in a disclaimer that for PostgreSQL <-> PostgreSQL connection people should be using the postgres_fdw driver.