### PR TITLE
Fix include of optimizer/appendinfo.h on PG 10/11

### DIFF
--- a/ogr_fdw.h
+++ b/ogr_fdw.h
@@ -40,7 +40,6 @@
 #include "miscadmin.h"
 #include "nodes/makefuncs.h"
 #include "nodes/nodeFuncs.h"
-#include "optimizer/appendinfo.h"
 #include "optimizer/clauses.h"
 #include "optimizer/cost.h"
 #include "optimizer/pathnode.h"
@@ -62,6 +61,7 @@
 #include "optimizer/var.h"
 #else
 #include "executor/tuptable.h"
+#include "optimizer/appendinfo.h"
 #endif
 
 #ifdef PACKAGE_URL


### PR DESCRIPTION
optimizer/appendinfo.h is only available in PG 12+.

This extends the fix for #231.