### PR TITLE
Regress fixes for PG14 and PG15 and simplification

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,8 +29,6 @@ jobs:
 
     - name: 'Install GDAL'
       run: |
-        sudo add-apt-repository ppa:ubuntugis/ppa
-        sudo apt-get update
         sudo apt-get install libgdal-dev
 
     - name: 'Install PostgreSQL'
@@ -45,6 +43,8 @@ jobs:
         export PGDATA=/var/lib/postgresql/${{ matrix.ci.PGVER }}/main
         export PGETC=/etc/postgresql/${{ matrix.ci.PGVER }}/main
         export PGBIN=/usr/lib/postgresql/${{ matrix.ci.PGVER }}/bin
+        export RUNNER_USER=`whoami`
+        sudo chmod -R 755 /home/${RUNNER_USER}
         # sudo su postgres -c "$PGBIN/pg_ctl --pgdata $PGDATA stop"
         # sudo $PGBIN/pg_ctlcluster ${{ matrix.ci.PGVER }} main stop
         sudo cp ./ci/pg_hba.conf $PGETC/pg_hba.conf


### PR DESCRIPTION
 - Just use libgdal-dev from main repo, its 3.4 still same as ubuntugis
 - Allow read of source folder

This mostly sets the permission of the folders so PG14 and PG15 regress cleanly.
I also got rid of ubuntugis because the version shipped with latest ubuntu is 3.4.1 (not too far from ubuntugis 3.4.3).  I'm mostly concerned about other things ubuntugis might bring in.  You can revert if you want.

The issue with PG13 is puzzling.  I tried wiping out all remnants of PostgreSQL and even setting priority of PostgreSQL install.

It seems to be actually creating a postgresql 14 folder to install things in.  So this might be a bug in apt.postgresql.org instead. I'll test later on ubuntu latest 13 to see if I get the same odd behavior.