### PR TITLE
README: Bump minimum supported PG version

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ OGR is the **vector** half of the [GDAL](http://www.gdal.org/) spatial data acce
 
 This implementation currently has the following limitations:
 
-* **PostgreSQL 9.3 or higher.** This wrapper does not support the FDW implementations in older versions of PostgreSQL.
+* **PostgreSQL 11 or higher.**
 * **Limited non-spatial query restrictions are pushed down to OGR.** OGR only supports a [minimal set](https://gdal.org/user/ogr_sql_dialect.html) of SQL operators (>, <, <=, >=, =).
 * **Only bounding box filters (&&) are pushed down.** Spatial filtering is possible, but only bounding boxes, and only using the && operator.
 * **OGR connections every time** Rather than pooling OGR connections, each query makes (and disposes of) **two** new ones, which seems to be the largest performance drag at the moment for restricted (small) queries.


### PR DESCRIPTION
PG10 fails now:

ogr_fdw.c:1122:18: error: ‘BOOLARRAYOID’ undeclared ... and other errors