### PR TITLE
Expose ogr_fdw_info functions via SQL

### DIFF
--- a/README.md
+++ b/README.md
@@ -426,6 +426,43 @@ ALTER SERVER myserver_latin1
 	);
 ```
 
+### FDW Reflection
+
+To view all GDAL table names available from a FDW server (the SQL equivalent of `ogr_fdw_info -s {datasource}`):
+
+```sql
+SELECT ogr_fdw_layers('myserver');
+```
+```
+ ogr_fdw_layers
+----------------
+ Cities
+ Countries
+
+(2 rows)
+```
+
+To retrieve the `CREATE FOREIGN TABLE` SQL for a particular OGR layer as the SQL equivalent of `ogr_fdw_info -s {datasource} -l {layer}`, use the `ogr_fdw_table_sql(server_name, ogr_layer_name, table_name=NULL, launder_column_names=TRUE, launder_table_name=TRUE)` function. By default the table name will reflect the OGR layer name. `launder_column_names` and `launder_table_name` have the same meaning as described in [Mixed Case and Special Characters](#mixed-case-and-special-characters).
+
+```sql
+SELECT ogr_fdw_table_sql('myserver', 'pt_two');
+```
+```
+        ogr_fdw_table_sql
+---------------------------------
+CREATE FOREIGN TABLE "pt_two" (
+  fid integer,
+  "geom" geometry(Point, 4326),
+  "name" varchar,
+  "age" integer,
+  "height" real,
+  "birthdate" date
+) SERVER "myserver"
+OPTIONS (layer 'pt_two');
+
+(1 row)
+```
+
 ### Utility Functions
 
 To view the current FDW and GDAL version.

--- a/input/import.source
+++ b/input/import.source
@@ -3,6 +3,9 @@ set client_min_messages=NOTICE;
 
 CREATE SCHEMA imp1;
 
+SELECT ogr_fdw_table_sql('myserver', '2launder');
+SELECT ogr_fdw_table_sql('myserver', '2launder', NULL, FALSE, FALSE);
+
 IMPORT FOREIGN SCHEMA ogr_all 
   LIMIT TO (n2launder) 
   FROM SERVER myserver 
@@ -22,6 +25,8 @@ SELECT * FROM imp1.n2launder WHERE fid = 0;
 ------------------------------------------------
 
 CREATE SCHEMA imp2;
+
+SELECT ogr_fdw_table_sql('myserver', 'natural', 'naturally');
 
 IMPORT FOREIGN SCHEMA ogr_all 
   LIMIT TO ("natural") 
@@ -46,6 +51,8 @@ CREATE SERVER svr_test_apost
     format 'CSV' );
 
 CREATE SCHEMA imp3;
+
+SELECT ogr_fdw_table_sql('svr_test_apost', 'no_geom_apost');
 
 IMPORT FOREIGN SCHEMA ogr_all 
   LIMIT TO (no_geom_apost) 

--- a/input/import.source
+++ b/input/import.source
@@ -3,6 +3,8 @@ set client_min_messages=NOTICE;
 
 CREATE SCHEMA imp1;
 
+SELECT ogr_fdw_layers('myserver');
+
 SELECT ogr_fdw_table_sql('myserver', '2launder');
 SELECT ogr_fdw_table_sql('myserver', '2launder', NULL, FALSE, FALSE);
 

--- a/ogr_fdw--1.1.sql
+++ b/ogr_fdw--1.1.sql
@@ -30,3 +30,10 @@ CREATE OR REPLACE FUNCTION ogr_fdw_drivers()
 	LANGUAGE 'c'
 	IMMUTABLE STRICT
 	PARALLEL SAFE;
+
+CREATE OR REPLACE FUNCTION ogr_fdw_table_sql(server_name text, layer_name text, table_name text DEFAULT NULL, launder_column_names boolean DEFAULT TRUE, launder_table_name boolean DEFAULT TRUE)
+	RETURNS text
+	AS 'MODULE_PATHNAME', 'ogr_fdw_table_sql'
+	LANGUAGE 'c'
+	STABLE
+	PARALLEL SAFE;

--- a/ogr_fdw--1.1.sql
+++ b/ogr_fdw--1.1.sql
@@ -37,3 +37,10 @@ CREATE OR REPLACE FUNCTION ogr_fdw_table_sql(server_name text, layer_name text, 
 	LANGUAGE 'c'
 	STABLE
 	PARALLEL SAFE;
+
+CREATE OR REPLACE FUNCTION ogr_fdw_layers(server_name text)
+	RETURNS TABLE (layer_name text)
+	AS 'MODULE_PATHNAME', 'ogr_fdw_layers'
+	LANGUAGE 'c'
+	IMMUTABLE STRICT
+	PARALLEL SAFE;

--- a/ogr_fdw.c
+++ b/ogr_fdw.c
@@ -507,7 +507,7 @@ ogrEreportError(const char* errstr)
  * Make sure the datasource is cleaned up when we're done
  * with a connection.
  */
-static void
+void
 ogrFinishConnection(OgrConnection* ogr)
 {
 	elog(DEBUG3, "%s: entered function", __func__);
@@ -525,7 +525,7 @@ ogrFinishConnection(OgrConnection* ogr)
 	ogr->ds = NULL;
 }
 
-static OgrConnection
+OgrConnection
 ogrGetConnectionFromServer(Oid foreignserverid, OgrUpdateable updateable)
 {
 	ForeignServer* server;

--- a/ogr_fdw.h
+++ b/ogr_fdw.h
@@ -208,4 +208,7 @@ bool ogrDeparse(StringInfo buf, PlannerInfo* root, RelOptInfo* foreignrel, List*
 Oid ogrGetGeometryOid(void);
 OGRErr pgDatumToOgrGeometry (Datum pg_geometry, Oid pgsendfunc, OGRGeometryH* ogr_geometry);
 
+OgrConnection ogrGetConnectionFromServer(Oid foreignserverid, OgrUpdateable updateable);
+void ogrFinishConnection(OgrConnection* ogr);
+
 #endif /* _OGR_FDW_H */

--- a/output/import.source
+++ b/output/import.source
@@ -1,6 +1,16 @@
 set client_min_messages=NOTICE;
 ------------------------------------------------
 CREATE SCHEMA imp1;
+SELECT ogr_fdw_layers('myserver');
+ ogr_fdw_layers 
+----------------
+ enc
+ pt_two
+ 2launder
+ poly
+ natural
+(5 rows)
+
 SELECT ogr_fdw_table_sql('myserver', '2launder');
                  ogr_fdw_table_sql                  
 ----------------------------------------------------

--- a/output/import.source
+++ b/output/import.source
@@ -1,6 +1,36 @@
 set client_min_messages=NOTICE;
 ------------------------------------------------
 CREATE SCHEMA imp1;
+SELECT ogr_fdw_table_sql('myserver', '2launder');
+                 ogr_fdw_table_sql                  
+----------------------------------------------------
+ CREATE FOREIGN TABLE n2launder (                  +
+   fid bigint,                                     +
+   geom bytea,                                     +
+   n2ame varchar(50) OPTIONS (column_name '2ame'), +
+   age integer,                                    +
+   height double precision,                        +
+   b_rthdate date OPTIONS (column_name 'b-rthdate')+
+ ) SERVER myserver                                 +
+ OPTIONS (layer '2launder');                       +
+ 
+(1 row)
+
+SELECT ogr_fdw_table_sql('myserver', '2launder', NULL, FALSE, FALSE);
+         ogr_fdw_table_sql         
+-----------------------------------
+ CREATE FOREIGN TABLE "2launder" (+
+   fid bigint,                    +
+   geom bytea,                    +
+   "2ame" varchar(50),            +
+   age integer,                   +
+   "Height" double precision,     +
+   "b-rthdate" date               +
+ ) SERVER myserver                +
+ OPTIONS (layer '2launder');      +
+ 
+(1 row)
+
 IMPORT FOREIGN SCHEMA ogr_all 
   LIMIT TO (n2launder) 
   FROM SERVER myserver 
@@ -31,6 +61,18 @@ SELECT * FROM imp1.n2launder WHERE fid = 0;
 
 ------------------------------------------------
 CREATE SCHEMA imp2;
+SELECT ogr_fdw_table_sql('myserver', 'natural', 'naturally');
+        ogr_fdw_table_sql         
+----------------------------------
+ CREATE FOREIGN TABLE naturally (+
+   fid bigint,                   +
+   id double precision,          +
+   "natural" varchar(4)          +
+ ) SERVER myserver               +
+ OPTIONS (layer 'natural');      +
+ 
+(1 row)
+
 IMPORT FOREIGN SCHEMA ogr_all 
   LIMIT TO ("natural") 
   FROM SERVER myserver 
@@ -64,6 +106,19 @@ CREATE SERVER svr_test_apost
     datasource '@abs_srcdir@/data/no_geom_apost.csv',
     format 'CSV' );
 CREATE SCHEMA imp3;
+SELECT ogr_fdw_table_sql('svr_test_apost', 'no_geom_apost');
+                        ogr_fdw_table_sql                         
+------------------------------------------------------------------
+ CREATE FOREIGN TABLE no_geom_apost (                            +
+   fid bigint,                                                   +
+   name varchar,                                                 +
+   age varchar,                                                  +
+   person_s_value varchar OPTIONS (column_name 'person''s value')+
+ ) SERVER svr_test_apost                                         +
+ OPTIONS (layer 'no_geom_apost');                                +
+ 
+(1 row)
+
 IMPORT FOREIGN SCHEMA ogr_all 
   LIMIT TO (no_geom_apost) 
   FROM SERVER svr_test_apost


### PR DESCRIPTION
I've found it useful to be able to introspect OGR datasources as the PostgreSQL server can see it — SQL equivalents of `ogr_fdw_info` commands.

1. Add a function to list available OGR layers from an FDW server:

    ```sql
    SELECT ogr_fdw_layers('myserver');
    ```
    ```
     ogr_fdw_layers
    ----------------
     Cities
     Countries
    
    (2 rows)
    ```

2. Add a function to get the `CREATE FOREIGN TABLE` SQL for a particular OGR layer, the same as `IMPORT FOREIGN SCHEMA` uses. This can help for issues where OGR is reporting column types wrongly, or some columns aren't needed but it's mostly correct.

    `ogr_fdw_table_sql(server_name, ogr_layer_name, table_name=NULL, launder_column_names=TRUE, launder_table_name=TRUE)`
    
    ```sql
    SELECT ogr_fdw_table_sql('myserver', 'pt_two');
    ```
    ```
            ogr_fdw_table_sql
    ---------------------------------
    CREATE FOREIGN TABLE "pt_two" (
      fid integer,
      "geom" geometry(Point, 4326),
      "name" varchar,
      "age" integer,
      "height" real,
      "birthdate" date
    ) SERVER "myserver"
    OPTIONS (layer 'pt_two');
    ```

---

Not sure on preferences whether you'd prefer the functions to take OIDs (eg: `SELECT ogr_fdw_layers(myserver);`) instead of names; and suggestions also very welcome on improvements for naming or docs.
