### PR TITLE
Fix build failure with GDAL 3.13.0.

### DIFF
--- a/ogr_fdw_info.c
+++ b/ogr_fdw_info.c
@@ -64,7 +64,11 @@ static char identifier[NAMEDATALEN+3];
 const char*
 quote_identifier(const char* ident)
 {
+#if GDAL_VERSION_NUM >= GDAL_COMPUTE_VERSION(3, 13, 0)
+	int len = (int)CPL_MIN(strlen(ident), NAMEDATALEN - 1);
+#else
 	int len = (int)MIN(strlen(ident), NAMEDATALEN - 1);
+#endif
 
 	if (reserved_word(ident))
 	{


### PR DESCRIPTION
```
error: implicit declaration of function 'MIN' [-Wimplicit-function-declaration]
```
https://github.com/OSGeo/gdal/commit/1f41ebcb4eaaad8ad5d81a789bf03ce9c20b3beb#diff-5e4656f11ffb922553c3e06f51ce9666886da91cfbc868ba4eac4c7515013c21